### PR TITLE
chore: add NuGet package metadata (repo URL, project URL)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+
+    <!-- NuGet package metadata -->
+    <Authors>Marcel Roozekrans</Authors>
+    <PackageProjectUrl>https://github.com/MarcelRoozekrans/ZMediator</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/MarcelRoozekrans/ZMediator</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.19">


### PR DESCRIPTION
## Summary
- Add `PackageProjectUrl`, `RepositoryUrl`, `RepositoryType`, and `Authors` to `Directory.Build.props`
- Ensures NuGet package displays source repo and project links on nuget.org

## Test Plan
- [x] All 58 unit tests pass
- [ ] Verify NuGet package metadata appears correctly after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)