### PR TITLE
feat: ZeroAlloc.Mediator rebrand, .NET 8 support, and Native AOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZeroAlloc.Mediator
 
-A zero-allocation mediator library for .NET 10. Uses a Roslyn incremental source generator to wire all dispatch at compile time — no reflection, no dictionaries, no virtual dispatch, no delegate allocation per request.
+A zero-allocation, Native AOT-compatible mediator library for .NET 8 and .NET 10. Uses a Roslyn incremental source generator to wire all dispatch at compile time — no reflection, no dictionaries, no virtual dispatch, no delegate allocation per request.
 
 ## Features
 
@@ -11,6 +11,7 @@ A zero-allocation mediator library for .NET 10. Uses a Roslyn incremental source
 - **Polymorphic Notifications** — base interface handlers are automatically included in concrete notification dispatch
 - **Analyzer Diagnostics** — missing handlers, duplicates, and misconfigurations are build errors/warnings
 - **Zero Allocation** — `ValueTask`, `readonly record struct`, static dispatch, no closures
+- **Native AOT Compatible** — no reflection at runtime; all dispatch is resolved at compile time by the source generator
 
 ## Quick Start
 

--- a/src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj
+++ b/src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj
@@ -3,5 +3,6 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>ZeroAlloc</RootNamespace>
     <PackageId>ZeroAlloc.Mediator</PackageId>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- **Full rebrand** from `ZMediator` → `ZeroAlloc.Mediator`: all namespaces, project names, solution file, CI/CD workflows, issue templates, and NuGet package IDs updated
- **Multi-targeting**: added .NET 8 LTS alongside .NET 10, with correct `netstandard2.0` generator target
- **Native AOT compatible**: declared `<IsAotCompatible>true</IsAotCompatible>` in the core package; README explicitly documents AOT support — zero runtime reflection, all dispatch wired at compile time by the source generator

## Test plan

- [x] All 58 tests pass on `net10.0` (`dotnet test --configuration Release`)
- [x] No secrets or sensitive files in the diff
- [x] CI/CD workflows updated to reference new solution and project paths
- [x] `assets/icon.png` included for NuGet listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)