### PR TITLE
ci: remove benchmark job from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,24 +50,3 @@ jobs:
         with:
           name: test-results
           path: "**/*.trx"
-
-  benchmark:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Run benchmarks
-        run: dotnet run --project tests/ZeroAlloc.Mediator.Benchmarks --configuration Release -- --filter "*" --exporters json
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results
-          path: BenchmarkDotNet.Artifacts/results/


### PR DESCRIPTION
## Summary

- Removes the `benchmark` job from the CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)