### PR TITLE
docs: fix code accuracy issues in advanced.md, testing.md, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,11 @@ The generator package must also be added as an analyzer:
 // 1. Define a request record and its expected response type
 public readonly record struct CreateOrder(string Product, int Qty) : IRequest<OrderId>;
 
-// 2. Implement a handler — constructor-injected dependencies are supported
-public class CreateOrderHandler(IOrderRepository repo) : IRequestHandler<CreateOrder, OrderId>
+// 2. Implement a handler — no constructor dependencies needed for this example
+public class CreateOrderHandler : IRequestHandler<CreateOrder, OrderId>
 {
-    public async ValueTask<OrderId> Handle(CreateOrder request, CancellationToken ct)
-    {
-        var id = await repo.InsertAsync(request.Product, request.Qty, ct);
-        return new OrderId(id);
-    }
+    public ValueTask<OrderId> Handle(CreateOrder request, CancellationToken ct)
+        => ValueTask.FromResult(OrderId.NewId());
 }
 
 // 3. Register IMediator with DI (the generator emits MediatorService automatically)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -45,7 +45,7 @@ The recommended pattern for cross-cutting exception handling is a pipeline behav
 
 ```csharp
 [PipelineBehavior(Order = 0)]
-public static class ExceptionHandlingBehavior
+public static class ExceptionHandlingBehavior : IPipelineBehavior
 {
     public static async ValueTask<TResponse> Handle<TRequest, TResponse>(
         TRequest request,
@@ -159,12 +159,8 @@ Without `[EnumeratorCancellation]`, the token passed to `CreateStream` is not fo
 ASP.NET Core automatically wires `HttpContext.RequestAborted` into the `CancellationToken` parameter of minimal API endpoints and controller actions. Pass it through to `Mediator.Send` or `CreateStream`:
 
 ```csharp
-app.MapGet("/orders/export", async (IMediator mediator, CancellationToken ct) =>
-{
-    await foreach (var row in mediator.CreateStream(new ExportOrdersQuery(), ct))
-        // If the client disconnects, ct is cancelled — the stream stops
-        yield return row;
-});
+app.MapGet("/orders/export", (IMediator mediator, CancellationToken ct) =>
+    mediator.CreateStream(new ExportOrdersQuery(), ct));
 ```
 
 ## Combining Features
@@ -230,7 +226,7 @@ For all other requests: `LoggingBehavior` → `PerformanceMonitorBehavior` → h
 
 ### The problem: static behaviors have no instance state
 
-Pipeline behaviors must be `static class` — the generator emits them as static method calls, not instantiated objects. This means you cannot inject services via a constructor. For stateless cross-cutting concerns (logging via `Console`, performance counters, lightweight validation) this is fine.
+Pipeline behaviors require a `static` `Handle` method — the generator emits them as static method calls, not instantiated objects. The class itself does not need to be `static`, but because `Handle` is static, you cannot inject services via a constructor. For stateless cross-cutting concerns (logging via `Console`, performance counters, lightweight validation) this is fine.
 
 For behaviors that genuinely need a scoped service (e.g., `DbContext`, `ICurrentUserService`, or a per-request audit log), use an ambient context pattern:
 
@@ -244,7 +240,7 @@ builder.Services.AddHttpContextAccessor();
 
 // In a behavior that needs the current user
 [PipelineBehavior(Order = 5)]
-public static class CurrentUserBehavior
+public static class CurrentUserBehavior : IPipelineBehavior
 {
     // Set once at startup via Mediator.Configure or DI wiring
     internal static IHttpContextAccessor? HttpContextAccessor;
@@ -272,7 +268,7 @@ For non-ASP.NET scenarios, use `AsyncLocal<T>` to flow a scoped value through th
 
 ```csharp
 [PipelineBehavior(Order = 0)]
-public static class TenantBehavior
+public static class TenantBehavior : IPipelineBehavior
 {
     private static readonly AsyncLocal<string?> _tenantId = new();
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,7 +105,9 @@ public class RequestIntegrationTests : IDisposable
 
     public void Dispose()
     {
-        // Reset factories between tests if needed
+        // Note: Mediator.Configure with an empty action is a no-op — it does NOT reset factories.
+        // To reset a factory between tests, call Configure again with the desired factory,
+        // or restructure the test to avoid shared factory state.
         Mediator.Configure(cfg => { });
     }
 }
@@ -143,8 +145,10 @@ Because `IMediator` contains strongly-typed overloads (one per request/notificat
 A pipeline behavior is a static class with a static `Handle` method. Test it by calling the method directly, passing a lambda as the `next` delegate:
 
 ```csharp
+// Note: in real usage, `: IPipelineBehavior` is required so the generator registers this behavior.
+// The tests below call the static method directly, so the interface is not strictly needed for isolation testing.
 [PipelineBehavior(Order = 0)]
-public static class ValidationBehavior
+public static class ValidationBehavior : IPipelineBehavior
 {
     public static async ValueTask<TResponse> Handle<TRequest, TResponse>(
         TRequest request,


### PR DESCRIPTION
## Summary

Follow-up fixes caught during code quality review of the docs uniformization PR (#21).

- **`docs/advanced.md`**: Fix invalid `yield return` inside `async` lambda in streaming example; add missing `: IPipelineBehavior` to all behavior examples; correct claim that behaviors must be `static class` (only `Handle` method needs to be static)
- **`docs/testing.md`**: Add missing `: IPipelineBehavior` to `ValidationBehavior`; fix misleading comment on `Mediator.Configure(cfg => { })` (it's a no-op, not a factory reset)
- **`README.md`**: Simplify Example handler to have no constructor dependency so `AddSingleton<IMediator, MediatorService>()` works as shown

## Test plan
- [ ] Verify all code blocks in advanced.md and testing.md compile correctly
- [ ] Verify README Example section is self-consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)