### PR TITLE
feat: telemetry spans + Cache/Validation/Resilience bridge packages + NuGet isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ obj/
 
 # BenchmarkDotNet output
 BenchmarkDotNet.Artifacts/
+
+!src/ZeroAlloc.Mediator.Cache/

--- a/ZeroAlloc.Mediator.slnx
+++ b/ZeroAlloc.Mediator.slnx
@@ -4,11 +4,17 @@
     <Project Path="samples/ZeroAlloc.Mediator.Sample/ZeroAlloc.Mediator.Sample.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj" />
     <Project Path="src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj" />
+    <Project Path="src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj" />
+    <Project Path="src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj" />
     <Project Path="src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Mediator.Benchmarks/ZeroAlloc.Mediator.Benchmarks.csproj" />
+    <Project Path="tests/ZeroAlloc.Mediator.Cache.Tests/ZeroAlloc.Mediator.Cache.Tests.csproj" />
+    <Project Path="tests/ZeroAlloc.Mediator.Resilience.Tests/ZeroAlloc.Mediator.Resilience.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Mediator.Tests/ZeroAlloc.Mediator.Tests.csproj" />
+    <Project Path="tests/ZeroAlloc.Mediator.Validation.Tests/ZeroAlloc.Mediator.Validation.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/ZeroAlloc.Mediator.Cache/CacheAttributeCache.cs
+++ b/src/ZeroAlloc.Mediator.Cache/CacheAttributeCache.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Mediator.Cache;
+
+// Per-TRequest type: one reflection call total on first access, then a static read forever.
+internal static class CacheAttributeCache<TRequest>
+{
+    internal static readonly CacheResponseAttribute? Attribute =
+        (CacheResponseAttribute?)System.Attribute.GetCustomAttribute(typeof(TRequest), typeof(CacheResponseAttribute));
+}

--- a/src/ZeroAlloc.Mediator.Cache/CacheBehavior.cs
+++ b/src/ZeroAlloc.Mediator.Cache/CacheBehavior.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Caching.Memory;
+using ZeroAlloc.Mediator;
+
+namespace ZeroAlloc.Mediator.Cache;
+
+/// <summary>
+/// Pipeline behavior that short-circuits with a cached response when the request type
+/// carries <see cref="CacheResponseAttribute"/>. Register globally via
+/// <see cref="MediatorCacheServiceCollectionExtensions.AddMediatorCache"/>;
+/// requests without the attribute pass through at the cost of one static field read per TRequest type.
+/// </summary>
+[PipelineBehavior]
+public sealed class CacheBehavior : IPipelineBehavior
+{
+    public static async ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request,
+        CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+    {
+        var attr = CacheAttributeCache<TRequest>.Attribute;
+        if (attr is null)
+            return await next(request, ct).ConfigureAwait(false);
+
+        var cache = CacheBehaviorState.Cache
+            ?? throw new InvalidOperationException(
+                "CacheBehavior requires IMemoryCache. Call services.AddMediatorCache() at startup and ensure " +
+                "MediatorCacheAccessor is resolved before the first cached request.");
+
+        var key = $"{typeof(TRequest).FullName ?? typeof(TRequest).Name}:{request}";
+
+        if (cache.TryGetValue(key, out TResponse? cached))
+            return cached!;
+
+        var result = await next(request, ct).ConfigureAwait(false);
+
+        if (attr.Sliding)
+            cache.Set(key, result, new MemoryCacheEntryOptions
+            {
+                SlidingExpiration = TimeSpan.FromMilliseconds(attr.TtlMs)
+            });
+        else
+            cache.Set(key, result, TimeSpan.FromMilliseconds(attr.TtlMs));
+
+        return result;
+    }
+}

--- a/src/ZeroAlloc.Mediator.Cache/CacheBehaviorState.cs
+++ b/src/ZeroAlloc.Mediator.Cache/CacheBehaviorState.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ZeroAlloc.Mediator.Cache;
+
+// Holds the resolved IMemoryCache. Populated by MediatorCacheAccessor on first DI resolution.
+// volatile ensures writes are visible across threads without reordering on weakly-ordered architectures.
+internal static class CacheBehaviorState
+{
+    internal static volatile IMemoryCache? Cache;
+
+    internal static void SetCache(IMemoryCache cache)
+    {
+        Cache = cache;
+    }
+}

--- a/src/ZeroAlloc.Mediator.Cache/CacheResponseAttribute.cs
+++ b/src/ZeroAlloc.Mediator.Cache/CacheResponseAttribute.cs
@@ -1,0 +1,17 @@
+namespace ZeroAlloc.Mediator.Cache;
+
+/// <summary>
+/// Marks an <see cref="ZeroAlloc.Mediator.IRequest{TResponse}"/> type so that
+/// <see cref="CacheBehavior"/> caches its response for the configured duration.
+/// Apply to the request type (struct or class), not to a service interface.
+/// </summary>
+// Inherited = false: each request type must declare [CacheResponse] independently.
+// Inheriting would give subclasses identical cache keys, which is almost always wrong.
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, Inherited = false)]
+public sealed class CacheResponseAttribute : Attribute
+{
+    /// <summary>Cache entry lifetime in milliseconds.</summary>
+    public required int TtlMs { get; init; }
+
+    public bool Sliding { get; init; } = false;
+}

--- a/src/ZeroAlloc.Mediator.Cache/MediatorCacheAccessor.cs
+++ b/src/ZeroAlloc.Mediator.Cache/MediatorCacheAccessor.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ZeroAlloc.Mediator.Cache;
+
+/// <summary>
+/// Singleton that bridges DI-managed <see cref="IMemoryCache"/> into the static
+/// <see cref="CacheBehavior"/> pipeline step. Resolving this singleton (which happens
+/// lazily on the first request that needs a cached response, or eagerly if the app
+/// resolves it explicitly) wires the cache into <see cref="CacheBehaviorState"/>.
+/// </summary>
+internal sealed class MediatorCacheAccessor
+{
+    internal MediatorCacheAccessor(IMemoryCache cache)
+    {
+        CacheBehaviorState.SetCache(cache);
+    }
+}

--- a/src/ZeroAlloc.Mediator.Cache/MediatorCacheServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Mediator.Cache/MediatorCacheServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZeroAlloc.Mediator.Cache;
+
+public static class MediatorCacheServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IMemoryCache"/> and wires it into <see cref="CacheBehavior"/>.
+    /// The cache is resolved from the container on the first cached request and pinned in a
+    /// static field — no per-call DI lookup after that.
+    /// </summary>
+    public static IServiceCollection AddMediatorCache(this IServiceCollection services)
+    {
+        // Idempotency guard — safe to call AddMediatorCache more than once.
+        if (services.Any(d => d.ServiceType == typeof(MediatorCacheAccessor)))
+            return services;
+
+        services.AddMemoryCache();
+
+        // Register using a factory so DI doesn't require a public constructor.
+        services.AddSingleton(sp => new MediatorCacheAccessor(sp.GetRequiredService<IMemoryCache>()));
+
+        // Eagerly resolve MediatorCacheAccessor so CacheBehaviorState.Cache is populated
+        // before the first cached request arrives, without requiring the consumer to pull an
+        // internal type from their container manually.
+        using var sp = services.BuildServiceProvider();
+        sp.GetRequiredService<MediatorCacheAccessor>();
+
+        return services;
+    }
+}

--- a/src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj
+++ b/src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Mediator.Cache</PackageId>
+    <Description>Pipeline behavior that caches IRequest&lt;T&gt; responses when the request type carries [Cache]. Zero-alloc key derivation via interpolated strings on value-type requests.</Description>
+    <Version>0.0.0-local</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ZeroAlloc.Mediator\ZeroAlloc.Mediator.csproj" />
+    <PackageReference Include="ZeroAlloc.Cache" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="ZeroAlloc.Mediator.Cache.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+  </ItemGroup>
+</Project>

--- a/src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj
+++ b/src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ZeroAlloc.Mediator\ZeroAlloc.Mediator.csproj" />
-    <PackageReference Include="ZeroAlloc.Cache" Version="1.0.0" />
+    <PackageReference Include="ZeroAlloc.Cache" Version="0.0.1" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ZeroAlloc.Mediator.Cache.Tests" />

--- a/src/ZeroAlloc.Mediator.Generator/MediatorGenerator.cs
+++ b/src/ZeroAlloc.Mediator.Generator/MediatorGenerator.cs
@@ -343,6 +343,10 @@ namespace ZeroAlloc.Mediator.Generator
             var validStreams = streamHandlers.Where(x => x != null).Select(x => x!).ToList();
             var validPipelines = pipelineBehaviors.ToList();
 
+            // Emit ActivitySource field
+            sb.AppendLine("        private static readonly global::System.Diagnostics.ActivitySource _activitySource = new(\"ZeroAlloc.Mediator\");");
+            sb.AppendLine();
+
             // Emit factory fields for request handlers
             foreach (var handler in validRequests)
             {
@@ -414,18 +418,27 @@ namespace ZeroAlloc.Mediator.Generator
                          && p.HasValidHandleMethod(expectedTypeParamCount: 2))
                 .ToList();
 
+            var requestSimpleName = GetSimpleTypeName(handler.RequestTypeName);
+
+            // async/await is required here so the activity span covers the full handler lifetime.
+            // This forces an async state machine allocation per call even for synchronous handlers —
+            // an accepted telemetry cost. A custom ValueTask wrapper could eliminate this in a future revision.
             sb.AppendLine(string.Format(
-                "        public static ValueTask<{0}> Send({1} request, CancellationToken ct = default)",
+                "        public static async ValueTask<{0}> Send({1} request, CancellationToken ct = default)",
                 handler.ResponseTypeName, handler.RequestTypeName));
             sb.AppendLine("        {");
+            sb.AppendLine("            using var __activity = _activitySource.StartActivity(\"mediator.send\");");
+            sb.AppendLine(string.Format("            __activity?.SetTag(\"request.type\", \"{0}\");", requestSimpleName));
+            sb.AppendLine("            try");
+            sb.AppendLine("            {");
 
             if (applicablePipelines.Count == 0)
             {
                 var fieldName = GetFactoryFieldName(handler.HandlerTypeName);
                 sb.AppendLine(string.Format(
-                    "            var handler = {0}?.Invoke() ?? new {1}();",
+                    "                var handler = {0}?.Invoke() ?? new {1}();",
                     fieldName, handler.HandlerTypeName));
-                sb.AppendLine("            return handler.Handle(request, ct);");
+                sb.AppendLine("                return await handler.Handle(request, ct);");
             }
             else
             {
@@ -444,9 +457,15 @@ namespace ZeroAlloc.Mediator.Generator
                 };
 
                 var chain = PipelineEmitter.EmitChain(applicablePipelines, shape);
-                sb.AppendLine(string.Format("            return {0};", chain));
+                sb.AppendLine(string.Format("                return await {0};", chain));
             }
 
+            sb.AppendLine("            }");
+            sb.AppendLine("            catch (global::System.Exception __ex)");
+            sb.AppendLine("            {");
+            sb.AppendLine("                __activity?.SetStatus(global::System.Diagnostics.ActivityStatusCode.Error, __ex.Message);");
+            sb.AppendLine("                throw;");
+            sb.AppendLine("            }");
             sb.AppendLine("        }");
             sb.AppendLine();
         }
@@ -482,12 +501,18 @@ namespace ZeroAlloc.Mediator.Generator
                 var allHandlers = new List<NotificationHandlerInfo>(handlerList);
                 allHandlers.AddRange(matchingBaseHandlers);
 
+                var notificationSimpleName = GetSimpleTypeName(notificationType);
+
                 if (isParallel)
                 {
                     sb.AppendLine(string.Format(
                         "        public static async ValueTask Publish({0} notification, CancellationToken ct = default)",
                         notificationType));
                     sb.AppendLine("        {");
+                    sb.AppendLine("            using var __activity = _activitySource.StartActivity(\"mediator.publish\");");
+                    sb.AppendLine(string.Format("            __activity?.SetTag(\"notification.type\", \"{0}\");", notificationSimpleName));
+                    sb.AppendLine("            try");
+                    sb.AppendLine("            {");
 
                     // Use Task.WhenAll for parallel execution
                     var taskExprs = new List<string>();
@@ -499,13 +524,19 @@ namespace ZeroAlloc.Mediator.Generator
                             fieldName, handler.HandlerTypeName));
                     }
 
-                    sb.AppendLine("            await Task.WhenAll(");
+                    sb.AppendLine("                await Task.WhenAll(");
                     for (int i = 0; i < taskExprs.Count; i++)
                     {
                         var comma = i < taskExprs.Count - 1 ? "," : "";
-                        sb.AppendLine(string.Format("                {0}{1}", taskExprs[i], comma));
+                        sb.AppendLine(string.Format("                    {0}{1}", taskExprs[i], comma));
                     }
-                    sb.AppendLine("            );");
+                    sb.AppendLine("                );");
+                    sb.AppendLine("            }");
+                    sb.AppendLine("            catch (global::System.Exception __ex)");
+                    sb.AppendLine("            {");
+                    sb.AppendLine("                __activity?.SetStatus(global::System.Diagnostics.ActivityStatusCode.Error, __ex.Message);");
+                    sb.AppendLine("                throw;");
+                    sb.AppendLine("            }");
                     sb.AppendLine("        }");
                 }
                 else
@@ -514,15 +545,25 @@ namespace ZeroAlloc.Mediator.Generator
                         "        public static async ValueTask Publish({0} notification, CancellationToken ct = default)",
                         notificationType));
                     sb.AppendLine("        {");
+                    sb.AppendLine("            using var __activity = _activitySource.StartActivity(\"mediator.publish\");");
+                    sb.AppendLine(string.Format("            __activity?.SetTag(\"notification.type\", \"{0}\");", notificationSimpleName));
+                    sb.AppendLine("            try");
+                    sb.AppendLine("            {");
 
                     foreach (var handler in allHandlers)
                     {
                         var fieldName = GetFactoryFieldName(handler.HandlerTypeName);
                         sb.AppendLine(string.Format(
-                            "            await ({0}?.Invoke() ?? new {1}()).Handle(notification, ct);",
+                            "                await ({0}?.Invoke() ?? new {1}()).Handle(notification, ct);",
                             fieldName, handler.HandlerTypeName));
                     }
 
+                    sb.AppendLine("            }");
+                    sb.AppendLine("            catch (global::System.Exception __ex)");
+                    sb.AppendLine("            {");
+                    sb.AppendLine("                __activity?.SetStatus(global::System.Diagnostics.ActivityStatusCode.Error, __ex.Message);");
+                    sb.AppendLine("                throw;");
+                    sb.AppendLine("            }");
                     sb.AppendLine("        }");
                 }
 
@@ -533,10 +574,15 @@ namespace ZeroAlloc.Mediator.Generator
         private static void EmitCreateStreamMethod(StringBuilder sb, StreamHandlerInfo handler)
         {
             var fieldName = GetFactoryFieldName(handler.HandlerTypeName);
+            var requestSimpleName = GetSimpleTypeName(handler.RequestTypeName);
             sb.AppendLine(string.Format(
                 "        public static System.Collections.Generic.IAsyncEnumerable<{0}> CreateStream({1} request, CancellationToken ct = default)",
                 handler.ResponseTypeName, handler.RequestTypeName));
             sb.AppendLine("        {");
+            // Span covers only iterator construction, not enumeration — "dispatch" semantics.
+            // Enumeration errors are not captured by this span.
+            sb.AppendLine("            using var __activity = _activitySource.StartActivity(\"mediator.stream\");");
+            sb.AppendLine(string.Format("            __activity?.SetTag(\"request.type\", \"{0}\");", requestSimpleName));
             sb.AppendLine(string.Format(
                 "            var handler = {0}?.Invoke() ?? new {1}();",
                 fieldName, handler.HandlerTypeName));

--- a/src/ZeroAlloc.Mediator.Resilience/MediatorCircuitBreakerAttribute.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorCircuitBreakerAttribute.cs
@@ -1,0 +1,9 @@
+namespace ZeroAlloc.Mediator.Resilience;
+
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, Inherited = false)]
+public sealed class MediatorCircuitBreakerAttribute : Attribute
+{
+    public int MaxFailures { get; init; } = 5;
+    public int ResetMs { get; init; } = 1_000;
+    public int HalfOpenProbes { get; init; } = 1;
+}

--- a/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceMarker.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceMarker.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Mediator.Resilience;
+
+/// <summary>
+/// Sentinel singleton used by the idempotency guard in
+/// <see cref="MediatorResilienceServiceCollectionExtensions.AddMediatorResilience"/>.
+/// Not intended for direct consumption.
+/// </summary>
+internal sealed class MediatorResilienceMarker;

--- a/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZeroAlloc.Mediator.Resilience;
+
+public static class MediatorResilienceServiceCollectionExtensions
+{
+    public static IServiceCollection AddMediatorResilience(this IServiceCollection services)
+    {
+        // Idempotency guard — safe to call AddMediatorResilience more than once.
+        if (services.Any(d => d.ServiceType == typeof(MediatorResilienceMarker)))
+            return services;
+
+        services.AddSingleton<MediatorResilienceMarker>();
+
+        return services;
+    }
+}

--- a/src/ZeroAlloc.Mediator.Resilience/MediatorRetryAttribute.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorRetryAttribute.cs
@@ -1,0 +1,10 @@
+namespace ZeroAlloc.Mediator.Resilience;
+
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, Inherited = false)]
+public sealed class MediatorRetryAttribute : Attribute
+{
+    public int MaxAttempts { get; init; } = 3;
+    public int BackoffMs { get; init; } = 200;
+    public bool Jitter { get; init; } = false;
+    public int PerAttemptTimeoutMs { get; init; } = 0;
+}

--- a/src/ZeroAlloc.Mediator.Resilience/MediatorTimeoutAttribute.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorTimeoutAttribute.cs
@@ -1,0 +1,7 @@
+namespace ZeroAlloc.Mediator.Resilience;
+
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, Inherited = false)]
+public sealed class MediatorTimeoutAttribute : Attribute
+{
+    public required int Ms { get; init; }
+}

--- a/src/ZeroAlloc.Mediator.Resilience/ResilienceAttributeCache.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/ResilienceAttributeCache.cs
@@ -1,0 +1,27 @@
+using ZeroAlloc.Resilience;
+
+namespace ZeroAlloc.Mediator.Resilience;
+
+internal static class ResilienceAttributeCache<TRequest>
+{
+    internal static readonly RetryPolicy? Retry;
+    internal static readonly CircuitBreakerPolicy? CircuitBreaker;
+    internal static readonly TimeoutPolicy? Timeout;
+
+    static ResilienceAttributeCache()
+    {
+        var type = typeof(TRequest);
+
+        var retry = (MediatorRetryAttribute?)Attribute.GetCustomAttribute(type, typeof(MediatorRetryAttribute));
+        if (retry is not null)
+            Retry = new RetryPolicy(retry.MaxAttempts, retry.BackoffMs, retry.Jitter, retry.PerAttemptTimeoutMs);
+
+        var cb = (MediatorCircuitBreakerAttribute?)Attribute.GetCustomAttribute(type, typeof(MediatorCircuitBreakerAttribute));
+        if (cb is not null)
+            CircuitBreaker = new CircuitBreakerPolicy(cb.MaxFailures, cb.ResetMs, cb.HalfOpenProbes);
+
+        var timeout = (MediatorTimeoutAttribute?)Attribute.GetCustomAttribute(type, typeof(MediatorTimeoutAttribute));
+        if (timeout is not null)
+            Timeout = new TimeoutPolicy(timeout.Ms);
+    }
+}

--- a/src/ZeroAlloc.Mediator.Resilience/ResilienceBehavior.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/ResilienceBehavior.cs
@@ -1,0 +1,140 @@
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Resilience;
+
+namespace ZeroAlloc.Mediator.Resilience;
+
+[PipelineBehavior]
+public sealed class ResilienceBehavior : IPipelineBehavior
+{
+    public static async ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request,
+        CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+    {
+        var retry    = ResilienceAttributeCache<TRequest>.Retry;
+        var cb       = ResilienceAttributeCache<TRequest>.CircuitBreaker;
+        var timeout  = ResilienceAttributeCache<TRequest>.Timeout;
+
+        // Fast path: no policies on this request type.
+        if (retry is null && cb is null && timeout is null)
+            return await next(request, ct).ConfigureAwait(false);
+
+        // Circuit breaker fast-reject (no attempt even started).
+        if (cb is not null && !cb.CanExecute())
+            throw new ResilienceException(
+                ResiliencePolicy.CircuitBreaker,
+                $"Circuit breaker for {typeof(TRequest).Name} is open.");
+
+        // Total-operation timeout CTS (wraps all retries + backoff).
+        CancellationTokenSource? totalCts = null;
+        if (timeout is not null)
+        {
+            totalCts = ct.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(ct)
+                : new CancellationTokenSource();
+            totalCts.CancelAfter(timeout.TotalMs);
+        }
+
+        try
+        {
+            var effectiveCt = totalCts?.Token ?? ct;
+
+            if (retry is not null)
+                return await ExecuteWithRetry<TRequest, TResponse>(request, next, retry, cb, effectiveCt)
+                    .ConfigureAwait(false);
+
+            // No retry — single attempt with optional circuit breaker.
+            return await ExecuteSingle<TRequest, TResponse>(request, next, cb, effectiveCt)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            totalCts?.Dispose();
+        }
+    }
+
+    // ── Single-attempt (no retry) ─────────────────────────────────────────────
+
+    private static async ValueTask<TResponse> ExecuteSingle<TRequest, TResponse>(
+        TRequest request,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next,
+        CircuitBreakerPolicy? cb,
+        CancellationToken ct)
+        where TRequest : IRequest<TResponse>
+    {
+        try
+        {
+            var result = await next(request, ct).ConfigureAwait(false);
+            cb?.OnSuccess();
+            return result;
+        }
+        catch (Exception ex)
+        {
+            cb?.OnFailure(ex);
+            throw;
+        }
+    }
+
+    // ── Retry loop ────────────────────────────────────────────────────────────
+
+    private static async ValueTask<TResponse> ExecuteWithRetry<TRequest, TResponse>(
+        TRequest request,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next,
+        RetryPolicy retry,
+        CircuitBreakerPolicy? cb,
+        CancellationToken totalCt)
+        where TRequest : IRequest<TResponse>
+    {
+        Exception? lastEx = null;
+
+        for (int attempt = 0; attempt < retry.MaxAttempts; attempt++)
+        {
+            // Per-attempt timeout: link against the total-timeout token.
+            CancellationTokenSource? attemptCts = null;
+            CancellationToken attemptCt;
+            if (retry.PerAttemptTimeoutMs > 0)
+            {
+                attemptCts = totalCt.CanBeCanceled
+                    ? CancellationTokenSource.CreateLinkedTokenSource(totalCt)
+                    : new CancellationTokenSource();
+                attemptCts.CancelAfter(retry.PerAttemptTimeoutMs);
+                attemptCt = attemptCts.Token;
+            }
+            else
+            {
+                attemptCt = totalCt;
+            }
+
+            try
+            {
+                var result = await next(request, attemptCt).ConfigureAwait(false);
+                cb?.OnSuccess();
+                return result;
+            }
+            catch (Exception ex)
+            {
+                lastEx = ex;
+                cb?.OnFailure(ex);
+
+                // per-attempt timeout fires OperationCanceledException; treat as transient failure and retry if attempts remain.
+                // Don't retry if the total-timeout elapsed.
+                if (totalCt.IsCancellationRequested) break;
+                // Don't delay after the last attempt.
+                if (attempt == retry.MaxAttempts - 1) break;
+
+                var backoffMs = retry.GetBackoffMs(attempt);
+                await Task.Delay(backoffMs, totalCt).ConfigureAwait(false);
+            }
+            finally
+            {
+                attemptCts?.Dispose();
+            }
+        }
+
+        throw new ResilienceException(
+            ResiliencePolicy.Retry,
+            $"All {retry.MaxAttempts} attempt(s) failed for {typeof(TRequest).Name}.",
+            lastEx);
+    }
+}

--- a/src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj
+++ b/src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Mediator.Resilience</PackageId>
+    <Description>Pipeline behavior that applies [MediatorRetry], [MediatorCircuitBreaker], and [MediatorTimeout] declared on request types. Composes ZeroAlloc.Resilience policies directly in the Mediator pipeline — no source generation required at the call site.</Description>
+    <Version>0.0.0-local</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ZeroAlloc.Mediator\ZeroAlloc.Mediator.csproj" />
+    <PackageReference Include="ZeroAlloc.Resilience" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="ZeroAlloc.Mediator.Resilience.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+  </ItemGroup>
+</Project>

--- a/src/ZeroAlloc.Mediator.Validation/FailureFactory.cs
+++ b/src/ZeroAlloc.Mediator.Validation/FailureFactory.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using ZeroAlloc.Results;
+
+namespace ZeroAlloc.Mediator.Validation;
+
+// Per-TResponse static cache. Populated once via reflection when TResponse is
+// Result<TValue, ValidationError> — zero-allocation on subsequent calls.
+internal static class FailureFactory<TResponse>
+{
+    internal static readonly Func<ValidationError, TResponse>? Create = BuildFactory();
+
+    private static Func<ValidationError, TResponse>? BuildFactory()
+    {
+        var responseType = typeof(TResponse);
+        if (!responseType.IsGenericType)
+            return null;
+
+        var def = responseType.GetGenericTypeDefinition();
+        if (def != typeof(Result<,>))
+            return null;
+
+        var typeArgs = responseType.GetGenericArguments();
+        // typeArgs[1] must be ValidationError
+        if (typeArgs[1] != typeof(ValidationError))
+            return null;
+
+        var method = responseType.GetMethod(
+            nameof(Result<object, ValidationError>.Failure),
+            BindingFlags.Public | BindingFlags.Static,
+            [typeof(ValidationError)]);
+        if (method is null) return null;
+
+        return method.CreateDelegate<Func<ValidationError, TResponse>>();
+    }
+}

--- a/src/ZeroAlloc.Mediator.Validation/MediatorValidationServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Mediator.Validation/MediatorValidationServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZeroAlloc.Mediator.Validation;
+
+public static class MediatorValidationServiceCollectionExtensions
+{
+    public static IServiceCollection AddMediatorValidation(this IServiceCollection services)
+    {
+        // Idempotency guard — safe to call AddMediatorValidation more than once.
+        if (services.Any(d => d.ServiceType == typeof(ValidationBehaviorAccessor)))
+            return services;
+
+        services.AddSingleton(sp => new ValidationBehaviorAccessor(sp));
+
+        return services;
+    }
+}

--- a/src/ZeroAlloc.Mediator.Validation/ValidationBehavior.cs
+++ b/src/ZeroAlloc.Mediator.Validation/ValidationBehavior.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Results;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Mediator.Validation;
+
+[PipelineBehavior]
+public sealed class ValidationBehavior : IPipelineBehavior
+{
+    public static async ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request,
+        CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+    {
+        var sp = ValidationBehaviorState.ServiceProvider;
+        if (sp is null)
+            return await next(request, ct).ConfigureAwait(false);
+
+        var validator = sp.GetService<ValidatorFor<TRequest>>();
+        if (validator is null)
+            return await next(request, ct).ConfigureAwait(false);
+
+        var validationResult = await validator.ValidateAsync(request, ct).ConfigureAwait(false);
+        if (!validationResult.IsValid)
+        {
+            var factory = FailureFactory<TResponse>.Create;
+            if (factory is null)
+                throw new ValidationFailedException(new ValidationError(validationResult.Failures.ToArray()));
+
+            return factory(new ValidationError(validationResult.Failures.ToArray()));
+        }
+
+        return await next(request, ct).ConfigureAwait(false);
+    }
+}

--- a/src/ZeroAlloc.Mediator.Validation/ValidationBehaviorAccessor.cs
+++ b/src/ZeroAlloc.Mediator.Validation/ValidationBehaviorAccessor.cs
@@ -1,0 +1,7 @@
+namespace ZeroAlloc.Mediator.Validation;
+
+internal sealed class ValidationBehaviorAccessor
+{
+    internal ValidationBehaviorAccessor(IServiceProvider serviceProvider) =>
+        ValidationBehaviorState.ServiceProvider = serviceProvider;
+}

--- a/src/ZeroAlloc.Mediator.Validation/ValidationBehaviorState.cs
+++ b/src/ZeroAlloc.Mediator.Validation/ValidationBehaviorState.cs
@@ -1,0 +1,6 @@
+namespace ZeroAlloc.Mediator.Validation;
+
+internal static class ValidationBehaviorState
+{
+    internal static volatile IServiceProvider? ServiceProvider;
+}

--- a/src/ZeroAlloc.Mediator.Validation/ValidationError.cs
+++ b/src/ZeroAlloc.Mediator.Validation/ValidationError.cs
@@ -1,0 +1,19 @@
+using System.Linq;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Mediator.Validation;
+
+public readonly struct ValidationError
+{
+    public ValidationError(ValidationFailure[] failures)
+    {
+        Failures = failures;
+    }
+
+    public ValidationFailure[] Failures { get; }
+
+    public override string ToString() =>
+        Failures is { Length: > 0 }
+            ? string.Join("; ", Failures.Select(f => $"{f.PropertyName}: {f.ErrorMessage}"))
+            : "Validation failed.";
+}

--- a/src/ZeroAlloc.Mediator.Validation/ValidationFailedException.cs
+++ b/src/ZeroAlloc.Mediator.Validation/ValidationFailedException.cs
@@ -1,0 +1,18 @@
+namespace ZeroAlloc.Mediator.Validation;
+
+// RCS1194: ValidationFailedException intentionally omits parameter-free constructors — a ValidationError is always required.
+#pragma warning disable RCS1194
+public sealed class ValidationFailedException : Exception
+{
+    public ValidationFailedException(ValidationError error)
+        : base(error.ToString()) => Error = error;
+
+    public ValidationFailedException(ValidationError error, string message)
+        : base(message) => Error = error;
+
+    public ValidationFailedException(ValidationError error, string message, Exception inner)
+        : base(message, inner) => Error = error;
+
+    public ValidationError Error { get; }
+}
+#pragma warning restore RCS1194

--- a/src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj
+++ b/src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Mediator.Validation</PackageId>
+    <Description>Pipeline behavior that validates IRequest&lt;T&gt; via ZeroAlloc.Validation before dispatch. Validation failures surface as Result&lt;T, ValidationError&gt; — no exceptions on the hot path.</Description>
+    <Version>0.0.0-local</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ZeroAlloc.Mediator\ZeroAlloc.Mediator.csproj" />
+    <PackageReference Include="ZeroAlloc.Validation" Version="0.2.3" />
+    <PackageReference Include="ZeroAlloc.Results" Version="0.1.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="ZeroAlloc.Mediator.Validation.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+  </ItemGroup>
+</Project>

--- a/tests/ZeroAlloc.Mediator.Cache.Tests/CacheBehaviorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Cache.Tests/CacheBehaviorTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Mediator.Cache;
+
+namespace ZeroAlloc.Mediator.Cache.Tests;
+
+// Disable parallelism for this collection — tests mutate the shared static CacheBehaviorState.Cache.
+[CollectionDefinition("non-parallel", DisableParallelization = true)]
+public sealed class NonParallelCollection { }
+
+// Request type without [CacheResponse] — passthrough expected.
+public readonly record struct UncachedRequest(int Value) : IRequest<int>;
+
+// Request type with [CacheResponse] — caching expected.
+[CacheResponse(TtlMs = 5000)]
+public readonly record struct CachedRequest(int Value) : IRequest<int>;
+
+// Request type with sliding [CacheResponse].
+[CacheResponse(TtlMs = 1000, Sliding = true)]
+public readonly record struct SlidingCachedRequest(int Value) : IRequest<string>;
+
+[Collection("non-parallel")]
+public class CacheBehaviorTests : IDisposable
+{
+    private readonly IMemoryCache _cache;
+
+    public CacheBehaviorTests()
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        CacheBehaviorState.SetCache(_cache);
+    }
+
+    public void Dispose() => _cache.Dispose();
+
+    [Fact]
+    public async Task Handle_RequestWithoutAttribute_PassesThrough()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(UncachedRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value * 2);
+        }
+
+        var result1 = await CacheBehavior.Handle(new UncachedRequest(3), CancellationToken.None, Next);
+        var result2 = await CacheBehavior.Handle(new UncachedRequest(3), CancellationToken.None, Next);
+
+        Assert.Equal(6, result1);
+        Assert.Equal(6, result2);
+        Assert.Equal(2, callCount); // not cached — next called twice
+    }
+
+    [Fact]
+    public async Task Handle_RequestWithAttribute_ReturnsCachedValueOnSecondCall()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(CachedRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value * 10);
+        }
+
+        var result1 = await CacheBehavior.Handle(new CachedRequest(7), CancellationToken.None, Next);
+        var result2 = await CacheBehavior.Handle(new CachedRequest(7), CancellationToken.None, Next);
+
+        Assert.Equal(70, result1);
+        Assert.Equal(70, result2);
+        Assert.Equal(1, callCount); // next called only once; second call hits cache
+    }
+
+    [Fact]
+    public async Task Handle_DifferentRequestValues_CachedSeparately()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(CachedRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value);
+        }
+
+        var result1 = await CacheBehavior.Handle(new CachedRequest(1), CancellationToken.None, Next);
+        var result2 = await CacheBehavior.Handle(new CachedRequest(2), CancellationToken.None, Next);
+
+        Assert.Equal(1, result1);
+        Assert.Equal(2, result2);
+        Assert.Equal(2, callCount); // distinct keys — both invocations hit next
+    }
+
+    [Fact]
+    public async Task Handle_SlidingCachedRequest_EntriesHitCache()
+    {
+        var callCount = 0;
+        ValueTask<string> Next(SlidingCachedRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult($"v{r.Value}");
+        }
+
+        var result1 = await CacheBehavior.Handle(new SlidingCachedRequest(5), CancellationToken.None, Next);
+        var result2 = await CacheBehavior.Handle(new SlidingCachedRequest(5), CancellationToken.None, Next);
+
+        Assert.Equal("v5", result1);
+        Assert.Equal("v5", result2);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task Handle_CacheNotConfigured_ThrowsInvalidOperationException()
+    {
+        CacheBehaviorState.SetCache(null!);
+        try
+        {
+            ValueTask<int> Next(CachedRequest r, CancellationToken c) => ValueTask.FromResult(0);
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => CacheBehavior.Handle(new CachedRequest(1), CancellationToken.None, Next).AsTask());
+        }
+        finally
+        {
+            CacheBehaviorState.SetCache(_cache);
+        }
+    }
+
+    [Fact]
+    public void AddMediatorCache_RegistersMemoryCache()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorCache();
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IMemoryCache>());
+    }
+
+    [Fact]
+    public void AddMediatorCache_ResolvingAccessorWiresCacheBehaviorState()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorCache();
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<MediatorCacheAccessor>();
+
+        Assert.NotNull(CacheBehaviorState.Cache);
+
+        // Restore for other tests in the same run.
+        CacheBehaviorState.SetCache(_cache);
+    }
+}

--- a/tests/ZeroAlloc.Mediator.Cache.Tests/ZeroAlloc.Mediator.Cache.Tests.csproj
+++ b/tests/ZeroAlloc.Mediator.Cache.Tests/ZeroAlloc.Mediator.Cache.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- MA0048: test types intentionally grouped; MA0051: test methods may be long. -->
+    <NoWarn>$(NoWarn);MA0048;MA0051</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Cache\ZeroAlloc.Mediator.Cache.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ZeroAlloc.Mediator.Resilience.Tests/ResilienceBehaviorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Resilience.Tests/ResilienceBehaviorTests.cs
@@ -1,0 +1,245 @@
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Mediator.Resilience;
+using ZeroAlloc.Resilience;
+
+namespace ZeroAlloc.Mediator.Resilience.Tests;
+
+// ── Request fixtures ──────────────────────────────────────────────────────────
+
+public readonly record struct PlainRequest(int Value) : IRequest<int>;
+
+[MediatorRetry(MaxAttempts = 3, BackoffMs = 1)]
+public readonly record struct RetryRequest(int Value) : IRequest<int>;
+
+[MediatorRetry(MaxAttempts = 2, BackoffMs = 1)]
+[MediatorTimeout(Ms = 5_000)]
+public readonly record struct RetryWithTimeoutRequest(int Value) : IRequest<int>;
+
+[MediatorRetry(MaxAttempts = 2, BackoffMs = 1, PerAttemptTimeoutMs = 2_000)]
+public readonly record struct PerAttemptTimeoutRequest(int Value) : IRequest<int>;
+
+[MediatorCircuitBreaker(MaxFailures = 2, ResetMs = 60_000, HalfOpenProbes = 1)]
+public readonly record struct CbRequest(int Value) : IRequest<int>;
+
+// Dedicated type for the circuit-open trip test — isolates its circuit state from CbRequest.
+[MediatorCircuitBreaker(MaxFailures = 2, ResetMs = 60_000)]
+public readonly record struct CbTripRequest(int Value) : IRequest<int>;
+
+[MediatorTimeout(Ms = 5_000)]
+public readonly record struct TimeoutRequest(int Value) : IRequest<int>;
+
+[MediatorTimeout(Ms = 50)]
+public readonly record struct ShortTimeoutRequest(int Value) : IRequest<int>;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+public sealed class ResilienceBehaviorTests
+{
+    // ── Passthrough ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_PlainRequest_PassesThroughWithNoOverhead()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(PlainRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value * 2);
+        }
+
+        var result = await ResilienceBehavior.Handle(new PlainRequest(5), CancellationToken.None, Next);
+
+        Assert.Equal(10, result);
+        Assert.Equal(1, callCount);
+    }
+
+    // ── Retry ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_RetryRequest_ReturnsOnFirstSuccess()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(RetryRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value);
+        }
+
+        var result = await ResilienceBehavior.Handle(new RetryRequest(42), CancellationToken.None, Next);
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task Handle_RetryRequest_RetriesOnFailureAndSucceeds()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(RetryRequest r, CancellationToken c)
+        {
+            callCount++;
+            if (callCount < 3)
+                throw new InvalidOperationException("transient");
+            return ValueTask.FromResult(99);
+        }
+
+        var result = await ResilienceBehavior.Handle(new RetryRequest(0), CancellationToken.None, Next);
+
+        Assert.Equal(99, result);
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public async Task Handle_RetryRequest_ThrowsAfterAllAttemptsExhausted()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(RetryRequest r, CancellationToken c)
+        {
+            callCount++;
+            throw new InvalidOperationException("always fails");
+        }
+
+        var ex = await Assert.ThrowsAsync<ResilienceException>(
+            () => ResilienceBehavior.Handle(new RetryRequest(0), CancellationToken.None, Next).AsTask());
+
+        Assert.Equal(ResiliencePolicy.Retry, ex.Policy);
+        Assert.Equal(3, callCount); // MaxAttempts = 3
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    // ── Timeout ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_TimeoutRequest_SucceedsWhenWithinTimeout()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(TimeoutRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value);
+        }
+
+        var result = await ResilienceBehavior.Handle(new TimeoutRequest(7), CancellationToken.None, Next);
+
+        Assert.Equal(7, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task Handle_TimeoutRequest_CancelsWhenTimeoutElapses()
+    {
+        // ShortTimeoutRequest carries [MediatorTimeout(Ms = 50)].
+        // The next delegate awaits forever, so the behavior's totalCts.CancelAfter(50) fires first.
+        static async ValueTask<int> Next(ShortTimeoutRequest r, CancellationToken ct)
+        {
+            await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+            return 0;
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => ResilienceBehavior.Handle(new ShortTimeoutRequest(0), CancellationToken.None, Next).AsTask());
+    }
+
+    // ── Circuit Breaker ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_CbRequest_SucceedsWhenCircuitClosed()
+    {
+        var callCount = 0;
+        ValueTask<int> Next(CbRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(r.Value);
+        }
+
+        var result = await ResilienceBehavior.Handle(new CbRequest(3), CancellationToken.None, Next);
+
+        Assert.Equal(3, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task Handle_CbRequest_ThrowsWhenCircuitOpen()
+    {
+        // Trip the circuit by injecting failures directly into the cached policy.
+        // Uses CbTripRequest (dedicated type) so its circuit state is fully isolated.
+        var cb = ResilienceAttributeCache<CbTripRequest>.CircuitBreaker!;
+
+        // Record enough failures to trip the circuit (MaxFailures = 2).
+        cb.OnFailure(new InvalidOperationException("f1"));
+        cb.OnFailure(new InvalidOperationException("f2"));
+
+        var callCount = 0;
+        ValueTask<int> Next(CbTripRequest r, CancellationToken c)
+        {
+            callCount++;
+            return ValueTask.FromResult(0);
+        }
+
+        // Circuit should now be open — behavior throws immediately.
+        var ex = await Assert.ThrowsAsync<ResilienceException>(
+            () => ResilienceBehavior.Handle(new CbTripRequest(0), CancellationToken.None, Next).AsTask());
+
+        Assert.Equal(ResiliencePolicy.CircuitBreaker, ex.Policy);
+        Assert.Equal(0, callCount); // next was never called
+    }
+
+    // ── DI extension ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddMediatorResilience_RegistersMarker()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorResilience();
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<MediatorResilienceMarker>());
+    }
+
+    [Fact]
+    public void AddMediatorResilience_IsIdempotent()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorResilience();
+        services.AddMediatorResilience(); // second call must not throw or double-register
+
+        var registrations = services.Count(d => d.ServiceType == typeof(MediatorResilienceMarker));
+        Assert.Equal(1, registrations);
+    }
+
+    // ── Attribute cache ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResilienceAttributeCache_PlainRequest_HasNoPolicies()
+    {
+        Assert.Null(ResilienceAttributeCache<PlainRequest>.Retry);
+        Assert.Null(ResilienceAttributeCache<PlainRequest>.CircuitBreaker);
+        Assert.Null(ResilienceAttributeCache<PlainRequest>.Timeout);
+    }
+
+    [Fact]
+    public void ResilienceAttributeCache_RetryRequest_HasRetryPolicy()
+    {
+        var retry = ResilienceAttributeCache<RetryRequest>.Retry;
+        Assert.NotNull(retry);
+        Assert.Equal(3, retry!.MaxAttempts);
+        Assert.Equal(1, retry.BackoffMs);
+    }
+
+    [Fact]
+    public void ResilienceAttributeCache_CbRequest_HasCircuitBreakerPolicy()
+    {
+        var cb = ResilienceAttributeCache<CbRequest>.CircuitBreaker;
+        Assert.NotNull(cb);
+        Assert.Equal(CircuitBreakerState.Closed, cb!.State);
+    }
+
+    [Fact]
+    public void ResilienceAttributeCache_TimeoutRequest_HasTimeoutPolicy()
+    {
+        var timeout = ResilienceAttributeCache<TimeoutRequest>.Timeout;
+        Assert.NotNull(timeout);
+        Assert.Equal(5_000, timeout!.TotalMs);
+    }
+}

--- a/tests/ZeroAlloc.Mediator.Resilience.Tests/ZeroAlloc.Mediator.Resilience.Tests.csproj
+++ b/tests/ZeroAlloc.Mediator.Resilience.Tests/ZeroAlloc.Mediator.Resilience.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- MA0048: test types intentionally grouped; MA0051: test methods may be long. -->
+    <NoWarn>$(NoWarn);MA0048;MA0051</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Resilience\ZeroAlloc.Mediator.Resilience.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/CombinedGeneratorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/CombinedGeneratorTests.cs
@@ -86,7 +86,7 @@ public class CombinedGeneratorTests
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 
         // Send is generated with pipeline behavior inlined
-        Assert.Contains("public static ValueTask<string> Send(global::TestApp.Ping request", output);
+        Assert.Contains("public static async ValueTask<string> Send(global::TestApp.Ping request", output);
         Assert.Contains("LoggingBehavior.Handle", output);
 
         // Publish is generated for both notification types

--- a/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/RequestDispatchGeneratorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/RequestDispatchGeneratorTests.cs
@@ -27,7 +27,7 @@ public class RequestDispatchGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public static ValueTask<string> Send(global::TestApp.Ping request", output);
+        Assert.Contains("public static async ValueTask<string> Send(global::TestApp.Ping request", output);
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class RequestDispatchGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public static ValueTask<global::ZeroAlloc.Mediator.Unit> Send(global::TestApp.DoSomething request", output);
+        Assert.Contains("public static async ValueTask<global::ZeroAlloc.Mediator.Unit> Send(global::TestApp.DoSomething request", output);
     }
 
     [Fact]

--- a/tests/ZeroAlloc.Mediator.Validation.Tests/ValidationBehaviorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Validation.Tests/ValidationBehaviorTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Mediator.Validation;
+using ZeroAlloc.Results;
+using ZeroAlloc.Validation;
+
+namespace ZeroAlloc.Mediator.Validation.Tests;
+
+// -- Request / handler types --------------------------------------------------
+
+public readonly record struct ValidatedRequest(string Name) : IRequest<Result<string, ValidationError>>;
+public readonly record struct UnvalidatedRequest(int Value) : IRequest<int>;
+public readonly record struct ThrowingRequest(string Name) : IRequest<string>;
+
+// Manual ValidatorFor<T> — no generator needed in tests.
+public sealed class ValidatedRequestValidator : ValidatorFor<ValidatedRequest>
+{
+    public override ValidationResult Validate(ValidatedRequest instance)
+    {
+        if (string.IsNullOrWhiteSpace(instance.Name))
+            return new ValidationResult([new ValidationFailure { PropertyName = "Name", ErrorMessage = "must not be empty" }]);
+
+        return new ValidationResult([]);
+    }
+}
+
+public sealed class ThrowingRequestValidator : ValidatorFor<ThrowingRequest>
+{
+    public override ValidationResult Validate(ThrowingRequest instance)
+    {
+        if (string.IsNullOrWhiteSpace(instance.Name))
+            return new ValidationResult([new ValidationFailure { PropertyName = "Name", ErrorMessage = "must not be empty" }]);
+
+        return new ValidationResult([]);
+    }
+}
+
+// -- Tests --------------------------------------------------------------------
+
+// Tests mutate the shared static ValidationBehaviorState.ServiceProvider.
+[CollectionDefinition("non-parallel-validation", DisableParallelization = true)]
+public sealed class NonParallelValidationCollection { }
+
+[Collection("non-parallel-validation")]
+public class ValidationBehaviorTests : IDisposable
+{
+    public ValidationBehaviorTests()
+    {
+        ValidationBehaviorState.ServiceProvider = null;
+    }
+
+    public void Dispose()
+    {
+        ValidationBehaviorState.ServiceProvider = null;
+    }
+
+    [Fact]
+    public async Task NoValidatorRegistered_PassesThroughToNext()
+    {
+        var services = new ServiceCollection();
+        ValidationBehaviorState.ServiceProvider = services.BuildServiceProvider();
+
+        var nextCalled = false;
+        ValueTask<Result<string, ValidationError>> Next(ValidatedRequest r, CancellationToken c)
+        {
+            nextCalled = true;
+            return ValueTask.FromResult(Result<string, ValidationError>.Success(r.Name));
+        }
+
+        var result = await ValidationBehavior.Handle(
+            new ValidatedRequest("Alice"), CancellationToken.None, Next);
+
+        Assert.True(nextCalled);
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ValidatorRegistered_ValidationPasses_CallsNext()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ValidatorFor<ValidatedRequest>, ValidatedRequestValidator>();
+        ValidationBehaviorState.ServiceProvider = services.BuildServiceProvider();
+
+        var nextCalled = false;
+        ValueTask<Result<string, ValidationError>> Next(ValidatedRequest r, CancellationToken c)
+        {
+            nextCalled = true;
+            return ValueTask.FromResult(Result<string, ValidationError>.Success(r.Name));
+        }
+
+        var result = await ValidationBehavior.Handle(
+            new ValidatedRequest("Bob"), CancellationToken.None, Next);
+
+        Assert.True(nextCalled);
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Bob", result.Value);
+    }
+
+    [Fact]
+    public async Task ValidatorRegistered_ValidationFails_ReturnsFailureResult()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ValidatorFor<ValidatedRequest>, ValidatedRequestValidator>();
+        ValidationBehaviorState.ServiceProvider = services.BuildServiceProvider();
+
+        var nextCalled = false;
+        ValueTask<Result<string, ValidationError>> Next(ValidatedRequest r, CancellationToken c)
+        {
+            nextCalled = true;
+            return ValueTask.FromResult(Result<string, ValidationError>.Success(r.Name));
+        }
+
+        var result = await ValidationBehavior.Handle(
+            new ValidatedRequest(""), CancellationToken.None, Next);
+
+        Assert.False(nextCalled);
+        Assert.True(result.IsFailure);
+        Assert.Single(result.Error.Failures);
+        Assert.Equal("Name", result.Error.Failures[0].PropertyName);
+    }
+
+    [Fact]
+    public async Task NoServiceProvider_PassesThroughToNext()
+    {
+        ValidationBehaviorState.ServiceProvider = null;
+
+        var nextCalled = false;
+        ValueTask<int> Next(UnvalidatedRequest r, CancellationToken c)
+        {
+            nextCalled = true;
+            return ValueTask.FromResult(r.Value * 2);
+        }
+
+        var result = await ValidationBehavior.Handle(
+            new UnvalidatedRequest(5), CancellationToken.None, Next);
+
+        Assert.True(nextCalled);
+        Assert.Equal(10, result);
+    }
+
+    [Fact]
+    public void AddMediatorValidation_IsIdempotent()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorValidation();
+        services.AddMediatorValidation(); // second call must be a no-op
+
+        var count = services.Count(d => d.ServiceType == typeof(ValidationBehaviorAccessor));
+        Assert.Equal(1, count); // idempotent — only one registration expected
+    }
+
+    [Fact]
+    public async Task ValidatorRegistered_ValidationFails_NonResultResponse_ThrowsValidationFailedException()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ValidatorFor<ThrowingRequest>, ThrowingRequestValidator>();
+        ValidationBehaviorState.ServiceProvider = services.BuildServiceProvider();
+
+        ValueTask<string> Next(ThrowingRequest r, CancellationToken c) =>
+            ValueTask.FromResult(r.Name);
+
+        var ex = await Assert.ThrowsAsync<ValidationFailedException>(() =>
+            ValidationBehavior.Handle(
+                new ThrowingRequest(""), CancellationToken.None, Next).AsTask());
+
+        Assert.Single(ex.Error.Failures);
+        Assert.Equal("Name", ex.Error.Failures[0].PropertyName);
+        Assert.Equal("must not be empty", ex.Error.Failures[0].ErrorMessage);
+    }
+}

--- a/tests/ZeroAlloc.Mediator.Validation.Tests/ZeroAlloc.Mediator.Validation.Tests.csproj
+++ b/tests/ZeroAlloc.Mediator.Validation.Tests/ZeroAlloc.Mediator.Validation.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- MA0048: test types intentionally grouped; MA0051: test methods may be long; HLQ005: Assert.Single is an assertion, not LINQ. -->
+    <NoWarn>$(NoWarn);MA0048;MA0051;HLQ005</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Validation\ZeroAlloc.Mediator.Validation.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Add `ActivitySource` spans to generated Mediator send/publish/stream methods
- Add three new bridge sub-packages: `Mediator.Cache`, `Mediator.Validation`, `Mediator.Resilience`
- Replace all cross-repo `ProjectReference` entries with `PackageReference` for isolation builds
- Fix `.gitignore` false-positive: `*.cache` was silently ignoring `src/ZeroAlloc.Mediator.Cache/`

## Test plan
- [ ] `dotnet build` in a clean checkout — resolves via NuGet
- [ ] All existing tests pass: `dotnet test`
- [ ] `CachePipelineBehaviorTests`: second call hits cache (handler called once)
- [ ] `ValidationPipelineBehaviorTests`: invalid request returns `IsFailure`
- [ ] Spans appear in OpenTelemetry output for Send/Publish/CreateStream

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)