### PR TITLE
feat(mediator.cache)!: rename AddMediatorCache to WithCache on IMediatorBuilder

### DIFF
--- a/src/ZeroAlloc.Mediator.Cache/CacheBehavior.cs
+++ b/src/ZeroAlloc.Mediator.Cache/CacheBehavior.cs
@@ -6,7 +6,7 @@ namespace ZeroAlloc.Mediator.Cache;
 /// <summary>
 /// Pipeline behavior that short-circuits with a cached response when the request type
 /// carries <see cref="CacheResponseAttribute"/>. Register globally via
-/// <see cref="MediatorCacheServiceCollectionExtensions.AddMediatorCache"/>;
+/// <see cref="MediatorCacheServiceCollectionExtensions.WithCache"/>;
 /// requests without the attribute pass through at the cost of one static field read per TRequest type.
 /// </summary>
 [PipelineBehavior]
@@ -24,7 +24,7 @@ public sealed class CacheBehavior : IPipelineBehavior
 
         var cache = CacheBehaviorState.Cache
             ?? throw new InvalidOperationException(
-                "CacheBehavior requires IMemoryCache. Call services.AddMediatorCache() at startup and ensure " +
+                "CacheBehavior requires IMemoryCache. Call services.AddMediator().WithCache() at startup and ensure " +
                 "MediatorCacheAccessor is resolved before the first cached request.");
 
         var key = $"{typeof(TRequest).FullName ?? typeof(TRequest).Name}:{request}";

--- a/src/ZeroAlloc.Mediator.Cache/MediatorCacheServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Mediator.Cache/MediatorCacheServiceCollectionExtensions.cs
@@ -1,20 +1,24 @@
+using System;
+using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
 
 namespace ZeroAlloc.Mediator.Cache;
 
 public static class MediatorCacheServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers <see cref="IMemoryCache"/> and wires it into <see cref="CacheBehavior"/>.
-    /// The cache is resolved from the container on the first cached request and pinned in a
-    /// static field — no per-call DI lookup after that.
+    /// Registers <see cref="IMemoryCache"/> and the cache pipeline-behavior accessor.
+    /// Idempotent — safe to call more than once.
     /// </summary>
-    public static IServiceCollection AddMediatorCache(this IServiceCollection services)
+    public static IMediatorBuilder WithCache(this IMediatorBuilder builder)
     {
-        // Idempotency guard — safe to call AddMediatorCache more than once.
+        var services = builder.Services;
+
+        // Idempotency guard — safe to call WithCache more than once.
         if (services.Any(d => d.ServiceType == typeof(MediatorCacheAccessor)))
-            return services;
+            return builder;
 
         services.AddMemoryCache();
 
@@ -27,6 +31,22 @@ public static class MediatorCacheServiceCollectionExtensions
         using var sp = services.BuildServiceProvider();
         sp.GetRequiredService<MediatorCacheAccessor>();
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy v1.x entry point. Use <see cref="WithCache"/> on the builder returned by
+    /// <c>services.AddMediator()</c> instead. Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use services.AddMediator().WithCache() instead. Will be removed in the next major.", DiagnosticId = "ZAMED001")]
+    public static IServiceCollection AddMediatorCache(this IServiceCollection services)
+    {
+        // Equivalent to services.AddMediator().WithCache(), but the generated AddMediator()
+        // extension is emitted into consuming projects and isn't visible inside this library —
+        // call IMediatorBuilder.Create directly. Consumers should still call AddMediator()
+        // themselves to register IMediator; the back-compat contract here is only that the
+        // cache accessor + IMemoryCache get registered.
+        IMediatorBuilder.Create(services).WithCache();
         return services;
     }
 }

--- a/tests/ZeroAlloc.Mediator.Cache.Tests/CacheBehaviorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Cache.Tests/CacheBehaviorTests.cs
@@ -20,6 +20,25 @@ public readonly record struct CachedRequest(int Value) : IRequest<int>;
 [CacheResponse(TtlMs = 1000, Sliding = true)]
 public readonly record struct SlidingCachedRequest(int Value) : IRequest<string>;
 
+// Stub handlers — exist only to satisfy the source generator's ZAM001 diagnostic
+// (every IRequest<T> needs a registered handler). The actual cache tests bypass
+// the dispatcher by calling CacheBehavior.Handle directly with a local lambda,
+// so these are never invoked.
+public sealed class UncachedRequestHandler : IRequestHandler<UncachedRequest, int>
+{
+    public ValueTask<int> Handle(UncachedRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class CachedRequestHandler : IRequestHandler<CachedRequest, int>
+{
+    public ValueTask<int> Handle(CachedRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class SlidingCachedRequestHandler : IRequestHandler<SlidingCachedRequest, string>
+{
+    public ValueTask<string> Handle(SlidingCachedRequest request, CancellationToken ct) => ValueTask.FromResult(string.Empty);
+}
+
 [Collection("non-parallel")]
 public class CacheBehaviorTests : IDisposable
 {
@@ -122,20 +141,20 @@ public class CacheBehaviorTests : IDisposable
     }
 
     [Fact]
-    public void AddMediatorCache_RegistersMemoryCache()
+    public void WithCache_RegistersMemoryCache()
     {
         var services = new ServiceCollection();
-        services.AddMediatorCache();
+        services.AddMediator().WithCache();
         using var provider = services.BuildServiceProvider();
 
         Assert.NotNull(provider.GetService<IMemoryCache>());
     }
 
     [Fact]
-    public void AddMediatorCache_ResolvingAccessorWiresCacheBehaviorState()
+    public void WithCache_ResolvingAccessorWiresCacheBehaviorState()
     {
         var services = new ServiceCollection();
-        services.AddMediatorCache();
+        services.AddMediator().WithCache();
         using var provider = services.BuildServiceProvider();
 
         provider.GetRequiredService<MediatorCacheAccessor>();
@@ -144,5 +163,14 @@ public class CacheBehaviorTests : IDisposable
 
         // Restore for other tests in the same run.
         CacheBehaviorState.SetCache(_cache);
+    }
+
+    [Fact]
+    public void AddMediatorCache_LegacyShim_StillRegistersAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorCache();   // shim — emits ZAMED001 warning, suppressed at csproj level
+
+        Assert.Contains(services, d => d.ServiceType == typeof(MediatorCacheAccessor));
     }
 }

--- a/tests/ZeroAlloc.Mediator.Cache.Tests/ZeroAlloc.Mediator.Cache.Tests.csproj
+++ b/tests/ZeroAlloc.Mediator.Cache.Tests/ZeroAlloc.Mediator.Cache.Tests.csproj
@@ -3,7 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- MA0048: test types intentionally grouped; MA0051: test methods may be long. -->
-    <NoWarn>$(NoWarn);MA0048;MA0051</NoWarn>
+    <!-- Suppress ZAMED001 in this test project so the legacy-shim back-compat tests
+         can deliberately call the obsolete AddMediatorCache(IServiceCollection) extension
+         without breaking TreatWarningsAsErrors. -->
+    <NoWarn>$(NoWarn);MA0048;MA0051;ZAMED001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
@@ -16,5 +19,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Cache\ZeroAlloc.Mediator.Cache.csproj" />
+    <!-- Pulls the source generator so services.AddMediator() is emitted into this test project,
+         letting tests exercise the canonical services.AddMediator().WithCache() form.
+         The generator depends on ZeroAlloc.Pipeline.Generators being loaded in the same
+         analyzer load context, so both must be referenced as analyzers. -->
+    <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Generator\ZeroAlloc.Mediator.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+    <PackageReference Include="ZeroAlloc.Pipeline.Generators" Version="$(ZeroAllocPipelineVersion)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="ZeroAlloc.Pipeline" Version="$(ZeroAllocPipelineVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Migrates `AddMediatorCache(this IServiceCollection)` to `WithCache(this IMediatorBuilder)` so it chains naturally off the new `services.AddMediator()` introduced in PR #46.

## Migration
```csharp
// Before
services.AddMediatorCache();

// After
services.AddMediator().WithCache();
```

The `AddMediatorCache(this IServiceCollection)` extension remains as an `[Obsolete]` shim with `DiagnosticId = "ZAMED001"` for one minor version, then is removed in the next major.

## Implementation note
The `[Obsolete]` shim body delegates via `IMediatorBuilder.Create(services).WithCache()` rather than `services.AddMediator().WithCache()`. The generated `AddMediator()` extension is emitted only into consumer projects (the source generator runs there), so it's not callable from inside the bridge library. Behavioral parity with v1.x is preserved — the v1.x shim never registered `IMediator` either; both v1.x and the new shim register only the cache accessor. Consumers wanting `IMediator` resolution should call `services.AddMediator()` themselves.

## Test plan
- [x] Existing `AddMediatorCache_*` tests adopted the new `WithCache()` form; renamed to `WithCache_*`. Stay green.
- [x] New `AddMediatorCache_LegacyShim_StillRegistersAccessor` covers back-compat
- [x] `<NoWarn>$(NoWarn);ZAMED001</NoWarn>` in test csproj for the deliberate shim-call
- [x] Stale `AddMediatorCache` references in `CacheBehavior.cs` xmldoc + exception message updated to `WithCache`
- [x] 8/8 in `Mediator.Cache.Tests`, 89/89 across all 4 test projects (baseline 88 + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)