### PR TITLE
feat(mediator.validation)!: rename AddMediatorValidation to WithValidation on IMediatorBuilder

### DIFF
--- a/src/ZeroAlloc.Mediator.Validation/MediatorValidationServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Mediator.Validation/MediatorValidationServiceCollectionExtensions.cs
@@ -1,17 +1,42 @@
+using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
 
 namespace ZeroAlloc.Mediator.Validation;
 
 public static class MediatorValidationServiceCollectionExtensions
 {
-    public static IServiceCollection AddMediatorValidation(this IServiceCollection services)
+    /// <summary>
+    /// Registers the validation pipeline-behavior accessor.
+    /// Idempotent — safe to call more than once.
+    /// </summary>
+    public static IMediatorBuilder WithValidation(this IMediatorBuilder builder)
     {
-        // Idempotency guard — safe to call AddMediatorValidation more than once.
+        var services = builder.Services;
+
+        // Idempotency guard — safe to call WithValidation more than once.
         if (services.Any(d => d.ServiceType == typeof(ValidationBehaviorAccessor)))
-            return services;
+            return builder;
 
         services.AddSingleton(sp => new ValidationBehaviorAccessor(sp));
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy v1.x entry point. Use <see cref="WithValidation"/> on the builder returned by
+    /// <c>services.AddMediator()</c> instead. Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use services.AddMediator().WithValidation() instead. Will be removed in the next major.", DiagnosticId = "ZAMED002")]
+    public static IServiceCollection AddMediatorValidation(this IServiceCollection services)
+    {
+        // Equivalent to services.AddMediator().WithValidation(), but the generated AddMediator()
+        // extension is emitted into consuming projects and isn't visible inside this library —
+        // call IMediatorBuilder.Create directly. Consumers should still call AddMediator()
+        // themselves to register IMediator; the back-compat contract here is only that the
+        // validation accessor gets registered.
+        IMediatorBuilder.Create(services).WithValidation();
         return services;
     }
 }

--- a/tests/ZeroAlloc.Mediator.Validation.Tests/ValidationBehaviorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Validation.Tests/ValidationBehaviorTests.cs
@@ -12,6 +12,26 @@ public readonly record struct ValidatedRequest(string Name) : IRequest<Result<st
 public readonly record struct UnvalidatedRequest(int Value) : IRequest<int>;
 public readonly record struct ThrowingRequest(string Name) : IRequest<string>;
 
+// Stub handlers — exist only to satisfy the source generator's ZAM001 diagnostic
+// (every IRequest<T> needs a registered handler). The actual validation tests bypass
+// the dispatcher by calling ValidationBehavior.Handle directly with a local lambda,
+// so these are never invoked.
+public sealed class ValidatedRequestHandler : IRequestHandler<ValidatedRequest, Result<string, ValidationError>>
+{
+    public ValueTask<Result<string, ValidationError>> Handle(ValidatedRequest request, CancellationToken ct) =>
+        ValueTask.FromResult(Result<string, ValidationError>.Success(request.Name));
+}
+
+public sealed class UnvalidatedRequestHandler : IRequestHandler<UnvalidatedRequest, int>
+{
+    public ValueTask<int> Handle(UnvalidatedRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class ThrowingRequestHandler : IRequestHandler<ThrowingRequest, string>
+{
+    public ValueTask<string> Handle(ThrowingRequest request, CancellationToken ct) => ValueTask.FromResult(string.Empty);
+}
+
 // Manual ValidatorFor<T> — no generator needed in tests.
 public sealed class ValidatedRequestValidator : ValidatorFor<ValidatedRequest>
 {
@@ -139,14 +159,24 @@ public class ValidationBehaviorTests : IDisposable
     }
 
     [Fact]
-    public void AddMediatorValidation_IsIdempotent()
+    public void WithValidation_IsIdempotent()
     {
         var services = new ServiceCollection();
-        services.AddMediatorValidation();
-        services.AddMediatorValidation(); // second call must be a no-op
+        var builder = services.AddMediator();
+        builder.WithValidation();
+        builder.WithValidation(); // second call must be a no-op
 
         var count = services.Count(d => d.ServiceType == typeof(ValidationBehaviorAccessor));
         Assert.Equal(1, count); // idempotent — only one registration expected
+    }
+
+    [Fact]
+    public void WithValidation_RegistersAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddMediator().WithValidation();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(ValidationBehaviorAccessor));
     }
 
     [Fact]
@@ -166,5 +196,14 @@ public class ValidationBehaviorTests : IDisposable
         Assert.Single(ex.Error.Failures);
         Assert.Equal("Name", ex.Error.Failures[0].PropertyName);
         Assert.Equal("must not be empty", ex.Error.Failures[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void AddMediatorValidation_LegacyShim_StillRegistersAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorValidation();   // shim — emits ZAMED002 warning, suppressed at csproj level
+
+        Assert.Contains(services, d => d.ServiceType == typeof(ValidationBehaviorAccessor));
     }
 }

--- a/tests/ZeroAlloc.Mediator.Validation.Tests/ZeroAlloc.Mediator.Validation.Tests.csproj
+++ b/tests/ZeroAlloc.Mediator.Validation.Tests/ZeroAlloc.Mediator.Validation.Tests.csproj
@@ -3,7 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- MA0048: test types intentionally grouped; MA0051: test methods may be long; HLQ005: Assert.Single is an assertion, not LINQ. -->
-    <NoWarn>$(NoWarn);MA0048;MA0051;HLQ005</NoWarn>
+    <!-- Suppress ZAMED002 in this test project so the legacy-shim back-compat tests
+         can deliberately call the obsolete AddMediatorValidation(IServiceCollection)
+         extension without breaking TreatWarningsAsErrors. -->
+    <NoWarn>$(NoWarn);MA0048;MA0051;HLQ005;ZAMED002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
@@ -16,5 +19,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Validation\ZeroAlloc.Mediator.Validation.csproj" />
+    <!-- Pulls the source generator so services.AddMediator() is emitted into this test project,
+         letting tests exercise the canonical services.AddMediator().WithValidation() form.
+         The generator depends on ZeroAlloc.Pipeline.Generators being loaded in the same
+         analyzer load context, so both must be referenced as analyzers. -->
+    <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Generator\ZeroAlloc.Mediator.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+    <PackageReference Include="ZeroAlloc.Pipeline.Generators" Version="$(ZeroAllocPipelineVersion)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="ZeroAlloc.Pipeline" Version="$(ZeroAllocPipelineVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Migrates `AddMediatorValidation(this IServiceCollection)` to `WithValidation(this IMediatorBuilder)` so it chains naturally off `services.AddMediator()` (PR #46). Mirrors the Cache migration in PR #48.

## Migration
```csharp
// Before
services.AddMediatorValidation();

// After
services.AddMediator().WithValidation();
```

The `AddMediatorValidation(this IServiceCollection)` extension remains as an `[Obsolete]` shim with `DiagnosticId = "ZAMED002"` for one minor version, then is removed in the next major.

## Implementation note
The `[Obsolete]` shim body delegates via `IMediatorBuilder.Create(services).WithValidation()` — same pattern as the Cache migration. The generated `AddMediator()` extension is emitted into consumer projects only, not callable from inside the bridge library. v1.x parity preserved (the shim registers only the validation accessor; users wanting `IMediator` resolution call `services.AddMediator()` themselves).

## Test plan
- [x] Existing `AddMediatorValidation_*` tests adopted the new `WithValidation()` form; renamed to `WithValidation_*`
- [x] New `AddMediatorValidation_LegacyShim_StillRegistersAccessor` covers back-compat
- [x] `<NoWarn>$(NoWarn);ZAMED002</NoWarn>` in test csproj
- [x] 8/8 in `Mediator.Validation.Tests`, 91/91 across all 4 test projects (baseline 89 + 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)