### PR TITLE
feat(mediator.resilience)!: rename AddMediatorResilience to WithResilience on IMediatorBuilder

### DIFF
--- a/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceMarker.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceMarker.cs
@@ -2,7 +2,7 @@ namespace ZeroAlloc.Mediator.Resilience;
 
 /// <summary>
 /// Sentinel singleton used by the idempotency guard in
-/// <see cref="MediatorResilienceServiceCollectionExtensions.AddMediatorResilience"/>.
+/// <see cref="MediatorResilienceServiceCollectionExtensions.WithResilience"/>.
 /// Not intended for direct consumption.
 /// </summary>
 internal sealed class MediatorResilienceMarker;

--- a/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceServiceCollectionExtensions.cs
+++ b/src/ZeroAlloc.Mediator.Resilience/MediatorResilienceServiceCollectionExtensions.cs
@@ -1,17 +1,42 @@
+using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Mediator;
 
 namespace ZeroAlloc.Mediator.Resilience;
 
 public static class MediatorResilienceServiceCollectionExtensions
 {
-    public static IServiceCollection AddMediatorResilience(this IServiceCollection services)
+    /// <summary>
+    /// Registers the resilience pipeline-behavior marker.
+    /// Idempotent — safe to call more than once.
+    /// </summary>
+    public static IMediatorBuilder WithResilience(this IMediatorBuilder builder)
     {
-        // Idempotency guard — safe to call AddMediatorResilience more than once.
+        var services = builder.Services;
+
+        // Idempotency guard — safe to call WithResilience more than once.
         if (services.Any(d => d.ServiceType == typeof(MediatorResilienceMarker)))
-            return services;
+            return builder;
 
         services.AddSingleton<MediatorResilienceMarker>();
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Legacy v1.x entry point. Use <see cref="WithResilience"/> on the builder returned by
+    /// <c>services.AddMediator()</c> instead. Will be removed in the next major.
+    /// </summary>
+    [Obsolete("Use services.AddMediator().WithResilience() instead. Will be removed in the next major.", DiagnosticId = "ZAMED003")]
+    public static IServiceCollection AddMediatorResilience(this IServiceCollection services)
+    {
+        // Equivalent to services.AddMediator().WithResilience(), but the generated AddMediator()
+        // extension is emitted into consuming projects and isn't visible inside this library —
+        // call IMediatorBuilder.Create directly. Consumers should still call AddMediator()
+        // themselves to register IMediator; the back-compat contract here is only that the
+        // resilience marker gets registered.
+        IMediatorBuilder.Create(services).WithResilience();
         return services;
     }
 }

--- a/tests/ZeroAlloc.Mediator.Resilience.Tests/ResilienceBehaviorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Resilience.Tests/ResilienceBehaviorTests.cs
@@ -32,6 +32,50 @@ public readonly record struct TimeoutRequest(int Value) : IRequest<int>;
 [MediatorTimeout(Ms = 50)]
 public readonly record struct ShortTimeoutRequest(int Value) : IRequest<int>;
 
+// Stub handlers — exist only to satisfy the source generator's ZAM001 diagnostic
+// (every IRequest<T> needs a registered handler). The actual resilience tests bypass
+// the dispatcher by calling ResilienceBehavior.Handle directly with a local lambda,
+// so these are never invoked.
+public sealed class PlainRequestHandler : IRequestHandler<PlainRequest, int>
+{
+    public ValueTask<int> Handle(PlainRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class RetryRequestHandler : IRequestHandler<RetryRequest, int>
+{
+    public ValueTask<int> Handle(RetryRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class RetryWithTimeoutRequestHandler : IRequestHandler<RetryWithTimeoutRequest, int>
+{
+    public ValueTask<int> Handle(RetryWithTimeoutRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class PerAttemptTimeoutRequestHandler : IRequestHandler<PerAttemptTimeoutRequest, int>
+{
+    public ValueTask<int> Handle(PerAttemptTimeoutRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class CbRequestHandler : IRequestHandler<CbRequest, int>
+{
+    public ValueTask<int> Handle(CbRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class CbTripRequestHandler : IRequestHandler<CbTripRequest, int>
+{
+    public ValueTask<int> Handle(CbTripRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class TimeoutRequestHandler : IRequestHandler<TimeoutRequest, int>
+{
+    public ValueTask<int> Handle(TimeoutRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
+public sealed class ShortTimeoutRequestHandler : IRequestHandler<ShortTimeoutRequest, int>
+{
+    public ValueTask<int> Handle(ShortTimeoutRequest request, CancellationToken ct) => ValueTask.FromResult(0);
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 public sealed class ResilienceBehaviorTests
@@ -188,24 +232,34 @@ public sealed class ResilienceBehaviorTests
     // ── DI extension ─────────────────────────────────────────────────────────
 
     [Fact]
-    public void AddMediatorResilience_RegistersMarker()
+    public void WithResilience_RegistersMarker()
     {
         var services = new ServiceCollection();
-        services.AddMediatorResilience();
+        services.AddMediator().WithResilience();
         using var provider = services.BuildServiceProvider();
 
         Assert.NotNull(provider.GetService<MediatorResilienceMarker>());
     }
 
     [Fact]
-    public void AddMediatorResilience_IsIdempotent()
+    public void WithResilience_IsIdempotent()
     {
         var services = new ServiceCollection();
-        services.AddMediatorResilience();
-        services.AddMediatorResilience(); // second call must not throw or double-register
+        var builder = services.AddMediator();
+        builder.WithResilience();
+        builder.WithResilience(); // second call must not throw or double-register
 
         var registrations = services.Count(d => d.ServiceType == typeof(MediatorResilienceMarker));
         Assert.Equal(1, registrations);
+    }
+
+    [Fact]
+    public void AddMediatorResilience_LegacyShim_StillRegistersMarker()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatorResilience();   // shim — emits ZAMED003 warning, suppressed at csproj level
+
+        Assert.Contains(services, d => d.ServiceType == typeof(MediatorResilienceMarker));
     }
 
     // ── Attribute cache ───────────────────────────────────────────────────────

--- a/tests/ZeroAlloc.Mediator.Resilience.Tests/ZeroAlloc.Mediator.Resilience.Tests.csproj
+++ b/tests/ZeroAlloc.Mediator.Resilience.Tests/ZeroAlloc.Mediator.Resilience.Tests.csproj
@@ -3,7 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- MA0048: test types intentionally grouped; MA0051: test methods may be long. -->
-    <NoWarn>$(NoWarn);MA0048;MA0051</NoWarn>
+    <!-- Suppress ZAMED003 in this test project so the legacy-shim back-compat tests
+         can deliberately call the obsolete AddMediatorResilience(IServiceCollection) extension
+         without breaking TreatWarningsAsErrors. -->
+    <NoWarn>$(NoWarn);MA0048;MA0051;ZAMED003</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
@@ -16,5 +19,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Resilience\ZeroAlloc.Mediator.Resilience.csproj" />
+    <!-- Pulls the source generator so services.AddMediator() is emitted into this test project,
+         letting tests exercise the canonical services.AddMediator().WithResilience() form.
+         The generator depends on ZeroAlloc.Pipeline.Generators being loaded in the same
+         analyzer load context, so both must be referenced as analyzers. -->
+    <ProjectReference Include="..\..\src\ZeroAlloc.Mediator.Generator\ZeroAlloc.Mediator.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+    <PackageReference Include="ZeroAlloc.Pipeline.Generators" Version="$(ZeroAllocPipelineVersion)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="ZeroAlloc.Pipeline" Version="$(ZeroAllocPipelineVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Migrates `AddMediatorResilience(this IServiceCollection)` to `WithResilience(this IMediatorBuilder)` so it chains naturally off `services.AddMediator()` (PR #46). Mirrors the Cache (PR #48) and Validation (PR #49) migrations.

This is the **last of the four bridge-package migrations** in the Mediator AddMediator() campaign. Once this lands, the full fluent surface is in place:

```csharp
services.AddMediator()
        .WithCache()
        .WithValidation()
        .WithResilience()
        .WithTelemetry();   // future, via ZeroAlloc.Mediator.Telemetry (Mediator#42)
```

## Migration
```csharp
// Before
services.AddMediatorResilience();

// After
services.AddMediator().WithResilience();
```

The `AddMediatorResilience(this IServiceCollection)` extension remains as an `[Obsolete]` shim with `DiagnosticId = "ZAMED003"` for one minor version, then is removed in the next major.

## Test plan
- [x] Existing `AddMediatorResilience_*` tests adopted the new `WithResilience()` form; renamed to `WithResilience_*`
- [x] New `AddMediatorResilience_LegacyShim_StillRegistersMarker` covers back-compat
- [x] `<NoWarn>$(NoWarn);ZAMED003</NoWarn>` in test csproj
- [x] Stale `AddMediatorResilience` xmldoc reference in `MediatorResilienceMarker.cs` updated to `WithResilience`
- [x] 15/15 in `Mediator.Resilience.Tests`, full suite green

## Order note
This PR is independent of PR #49 (Validation, also open). Merge order: #49 first, then #50, makes for a cleaner CHANGELOG, but they don't block each other technically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)