### PR TITLE
ci(release): publish bridge packages to NuGet

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           dotnet pack src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Mediator.Telemetry/ZeroAlloc.Mediator.Telemetry.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           dotnet pack src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Mediator.Cache/ZeroAlloc.Mediator.Cache.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Mediator.Telemetry/ZeroAlloc.Mediator.Telemetry.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
The release workflows previously only packed and pushed `ZeroAlloc.Mediator` and `ZeroAlloc.Mediator.Generator`. The four bridge packages — `Cache`, `Validation`, `Resilience`, and `Telemetry` — were never published to NuGet, making them effectively only usable as ProjectReferences.

This PR extends both `release-please.yml` and `release.yml` to pack and push all four bridges alongside the core packages.

## Affected packages (now publishable)
- `ZeroAlloc.Mediator.Cache`
- `ZeroAlloc.Mediator.Validation`
- `ZeroAlloc.Mediator.Resilience`
- `ZeroAlloc.Mediator.Telemetry` (new in #52)

## Test plan
- [x] `dotnet pack` succeeds for all 4 bridges locally
- [ ] Next release-please cycle publishes all 6 packages (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)