### PR TITLE
fix(mediator.generator)!: ship analyzer DLL under analyzers/dotnet/cs/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
           dotnet pack src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
 
+      - name: Verify generator pack layout
+        run: bash scripts/verify-generator-pack-layout.sh ./artifacts
+
       - name: Push to NuGet (pre-release)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,8 @@ jobs:
           dotnet pack src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Mediator.Telemetry/ZeroAlloc.Mediator.Telemetry.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
 
+      - name: Verify generator pack layout
+        run: bash scripts/verify-generator-pack-layout.sh ./artifacts
+
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/scripts/verify-generator-pack-layout.sh
+++ b/scripts/verify-generator-pack-layout.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Verify that ZeroAlloc.Mediator.Generator.<version>.nupkg ships its DLLs under
+# analyzers/dotnet/cs/ and not under lib/. A regression here means external
+# consumers of the package silently get no source generator (the consuming
+# project loads the DLL as a regular library reference instead of an analyzer).
+#
+# See: fix(mediator.generator)! ship analyzer DLL under analyzers/dotnet/cs/
+#
+# Usage:
+#   scripts/verify-generator-pack-layout.sh <artifacts-dir>
+#
+# Exits non-zero if the layout is wrong.
+
+set -euo pipefail
+
+ARTIFACTS_DIR="${1:-./artifacts}"
+
+if [[ ! -d "$ARTIFACTS_DIR" ]]; then
+  echo "ERROR: artifacts directory not found: $ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+# Locate the generator nupkg. There may be multiple version-suffixed candidates
+# (e.g. CI runs after release-please) — pick the first match.
+NUPKG=$(ls -1 "$ARTIFACTS_DIR"/ZeroAlloc.Mediator.Generator.*.nupkg 2>/dev/null | head -n 1 || true)
+
+if [[ -z "$NUPKG" ]]; then
+  echo "ERROR: no ZeroAlloc.Mediator.Generator.*.nupkg found in $ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+echo "Inspecting: $NUPKG"
+
+# A nupkg is a zip; list entries.
+ENTRIES=$(unzip -Z1 "$NUPKG")
+
+echo "--- nupkg entries ---"
+echo "$ENTRIES"
+echo "---------------------"
+
+# 1. Must contain the generator DLL under analyzers/dotnet/cs/.
+if ! grep -qE '^analyzers/dotnet/cs/ZeroAlloc\.Mediator\.Generator\.dll$' <<<"$ENTRIES"; then
+  echo "FAIL: ZeroAlloc.Mediator.Generator.dll missing from analyzers/dotnet/cs/" >&2
+  exit 1
+fi
+
+# 2. Must NOT contain any DLL under lib/ — that signals the bug returned.
+if grep -qE '^lib/.*\.dll$' <<<"$ENTRIES"; then
+  echo "FAIL: nupkg contains DLLs under lib/ — generator is being shipped as a regular library reference" >&2
+  echo "Offending entries:" >&2
+  grep -E '^lib/.*\.dll$' <<<"$ENTRIES" >&2
+  exit 1
+fi
+
+echo "OK: ZeroAlloc.Mediator.Generator nupkg layout is correct."

--- a/src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj
+++ b/src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj
@@ -6,6 +6,15 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
     <NoWarn>$(NoWarn);RS2008</NoWarn>
+
+    <!--
+      Source-generator packaging: ship the generator DLL under analyzers/dotnet/cs so
+      Roslyn loads it as an analyzer. Without IncludeBuildOutput=false the build output
+      ends up under lib/ and consumers silently get no source generator.
+    -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
@@ -32,4 +41,29 @@
           DestinationFolder="$(OutputPath)"
           SkipUnchangedFiles="true" />
   </Target>
+
+  <!--
+    Pack the generator DLL (and its helper dependencies, which Roslyn must register as
+    additional analyzers) under analyzers/dotnet/cs. Without this, dotnet pack falls back
+    to the default lib/<tfm>/ layout and consumers do not pick up the generator at all.
+  -->
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"
+          Condition="Exists('$(OutputPath)\$(AssemblyName).pdb')" />
+    <None Include="$(OutputPath)\ZeroAlloc.Pipeline.Generators.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\ZeroAlloc.Pipeline.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Bug

The published `ZeroAlloc.Mediator.Generator` v1.x packages place the generator DLL under `lib/netstandard2.0/` instead of `analyzers/dotnet/cs/`. When external consumers reference the package via

```xml
<PackageReference Include="ZeroAlloc.Mediator.Generator"
                  OutputItemType="Analyzer"
                  ReferenceOutputAssembly="false" />
```

MSBuild treats the DLL as a regular library reference. The source generator never runs, and `services.AddMediator()` is never emitted.

## Impact

Every external NuGet consumer of `ZeroAlloc.Mediator.Generator` is silently getting no source generator. The bug has been latent since the package was first published.

In-repo Mediator bridge projects (`ZeroAlloc.Mediator.Cache`, `.Validation`, `.Resilience`, `.Telemetry`) consume the generator via local `ProjectReference` — which uses `OutputItemType="Analyzer"` directly against project output and bypasses nupkg layout entirely. That's why CI never caught it.

## Discovery

Surfaced during `ZeroAlloc.Saga` PR #2 development, where an external consumer referenced the package via `PackageReference` and observed that the generator never produced output.

## Fix

`src/ZeroAlloc.Mediator.Generator/ZeroAlloc.Mediator.Generator.csproj`:

- Add `IncludeBuildOutput=false` / `SuppressDependenciesWhenPacking=true` / `DevelopmentDependency=true`.
- Pack the generator DLL + pdb under `analyzers/dotnet/cs/`.
- Pack the helper DLLs (`ZeroAlloc.Pipeline.Generators`, `ZeroAlloc.Pipeline`) under `analyzers/dotnet/cs/` as well — they're required next to the generator because Roslyn loads source generators in an isolated `AssemblyLoadContext` (this is already documented in `Directory.Build.targets`).

## Verification

Local `dotnet pack`, before vs after:

**Before (broken):**
```
lib/netstandard2.0/ZeroAlloc.Mediator.Generator.dll
```

**After (fixed):**
```
analyzers/dotnet/cs/ZeroAlloc.Mediator.Generator.dll
analyzers/dotnet/cs/ZeroAlloc.Mediator.Generator.pdb
analyzers/dotnet/cs/ZeroAlloc.Pipeline.Generators.dll
analyzers/dotnet/cs/ZeroAlloc.Pipeline.dll
```

No DLLs ship under `lib/` anymore.

There is no in-repo external test project that pulls Mediator.Generator via `PackageReference` (only `ProjectReference`), so this PR verifies the fix by direct nupkg-layout inspection rather than full end-to-end consumer build. The new CI guard pins that layout.

## CI guard

Added `scripts/verify-generator-pack-layout.sh`, invoked from both `ci.yml` and `release.yml` immediately after `dotnet pack`. The script:

1. Asserts `analyzers/dotnet/cs/ZeroAlloc.Mediator.Generator.dll` is present in the nupkg.
2. Asserts no DLL ships under `lib/`.

Tested locally against both the pre-fix nupkg (correctly fails) and post-fix nupkg (passes).

## Release

`Release-As: 2.0.1` is set in the commit footer. The API surface is unchanged; the user-visible effect is "the generator now actually works for NuGet consumers". A patch bump is the right shape, and `release-please-config.json` has `bump-patch-for-minor-pre-major: true` so a `fix:` commit would patch-bump regardless.

The `!` in the title denotes that this is a behavioral change for downstream packages (they now actually receive a generator), not a breaking API change.

## Related

No other generator packages in this repo are affected — Mediator.Generator is the only standalone-published generator nupkg. The bridge packages (`Cache`, `Validation`, `Resilience`, `Telemetry`) are runtime-only libraries and have no generator csproj of their own.

Cross-referenced sibling repos:
- `ZeroAlloc.Pipeline.Generators` — published standalone, but never had this bug because it doesn't set `IsRoslynComponent` and packs as a regular helper library.
- `ZeroAlloc.Validation.Generator` — `IsPackable=false`, bundled into the runtime package, not affected.
- `ZeroAlloc.Resilience.Generator` / `ZeroAlloc.StateMachine.Generator` — bundled into runtime packages, not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)