### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,14 +94,21 @@ jobs:
         run: dotnet build src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj -c Release -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
       - name: Pack current
         run: dotnet pack src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj -c Release --no-build --output ./current -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
-      - name: Compare against latest published 1.x
+      - name: Compare against latest published version
+        # Take the highest released version overall (no major filter). When you
+        # bump majors with intentional breaking changes, the FIRST build of the
+        # new major may still gate against the previous major — accept that as
+        # the cost of correctness. Steady-state, this gates each x.y.(z+1) patch
+        # against x.y.z and each x.(y+1).0 minor against x.y.(latest), which is
+        # what we want.
         run: |
           latest=$(curl -s https://api.nuget.org/v3-flatcontainer/zeroalloc.mediator/index.json \
-                   | jq -r '.versions[]' | grep -E '^1\.' | tail -1)
+                   | jq -r '.versions[]' | grep -vE '(-|preview|alpha|beta|rc)' | tail -1)
           if [ -z "$latest" ]; then
-            echo "No published 1.x yet — skipping baseline check."
+            echo "No stable releases on nuget.org yet — skipping baseline check."
             exit 0
           fi
+          echo "Comparing against published version: $latest"
           mkdir -p ./baseline
           curl -sL "https://api.nuget.org/v3-flatcontainer/zeroalloc.mediator/$latest/zeroalloc.mediator.$latest.nupkg" \
                -o ./baseline/baseline.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,30 @@ jobs:
 
       - name: Run AOT binary
         run: ./aot-out/ZeroAlloc.Mediator.AotSmoke
+
+  api-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - name: Install ApiCompat tool
+        run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+      - name: Build current (sentinel assembly version >= any baseline so CP0003 never fires)
+        run: dotnet build src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj -c Release -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
+      - name: Pack current
+        run: dotnet pack src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj -c Release --no-build --output ./current -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
+      - name: Compare against latest published 1.x
+        run: |
+          latest=$(curl -s https://api.nuget.org/v3-flatcontainer/zeroalloc.mediator/index.json \
+                   | jq -r '.versions[]' | grep -E '^1\.' | tail -1)
+          if [ -z "$latest" ]; then
+            echo "No published 1.x yet — skipping baseline check."
+            exit 0
+          fi
+          mkdir -p ./baseline
+          curl -sL "https://api.nuget.org/v3-flatcontainer/zeroalloc.mediator/$latest/zeroalloc.mediator.$latest.nupkg" \
+               -o ./baseline/baseline.nupkg
+          apicompat package ./current/*.nupkg --baseline-package ./baseline/baseline.nupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
 
     <!-- ZeroAlloc.Pipeline dependency version (used when local checkout is absent) -->
     <ZeroAllocPipelineVersion>0.1.1</ZeroAllocPipelineVersion>

--- a/src/ZeroAlloc.Mediator/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.Mediator/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Mediator/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Mediator/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Mediator/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Mediator/PublicAPI.Unshipped.txt
@@ -1,1 +1,28 @@
 #nullable enable
+override ZeroAlloc.Mediator.Unit.GetHashCode() -> int
+static ZeroAlloc.Mediator.Unit.operator !=(ZeroAlloc.Mediator.Unit left, ZeroAlloc.Mediator.Unit right) -> bool
+static ZeroAlloc.Mediator.Unit.operator ==(ZeroAlloc.Mediator.Unit left, ZeroAlloc.Mediator.Unit right) -> bool
+static readonly ZeroAlloc.Mediator.Unit.Value -> ZeroAlloc.Mediator.Unit
+ZeroAlloc.Mediator.IMediatorBuilder
+ZeroAlloc.Mediator.IMediatorBuilder.Create(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> ZeroAlloc.Mediator.IMediatorBuilder!
+ZeroAlloc.Mediator.IMediatorBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+ZeroAlloc.Mediator.INotification
+ZeroAlloc.Mediator.INotificationHandler<TNotification>
+ZeroAlloc.Mediator.INotificationHandler<TNotification>.Handle(TNotification notification, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Mediator.IPipelineBehavior
+ZeroAlloc.Mediator.IRequest
+ZeroAlloc.Mediator.IRequest<TResponse>
+ZeroAlloc.Mediator.IRequestHandler<TRequest, TResponse>
+ZeroAlloc.Mediator.IRequestHandler<TRequest, TResponse>.Handle(TRequest request, System.Threading.CancellationToken ct) -> System.Threading.Tasks.ValueTask<TResponse>
+ZeroAlloc.Mediator.IStreamRequest<TResponse>
+ZeroAlloc.Mediator.IStreamRequestHandler<TRequest, TResponse>
+ZeroAlloc.Mediator.IStreamRequestHandler<TRequest, TResponse>.Handle(TRequest request, System.Threading.CancellationToken ct) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+ZeroAlloc.Mediator.ParallelNotificationAttribute
+ZeroAlloc.Mediator.ParallelNotificationAttribute.ParallelNotificationAttribute() -> void
+ZeroAlloc.Mediator.PipelineBehaviorAttribute
+ZeroAlloc.Mediator.PipelineBehaviorAttribute.PipelineBehaviorAttribute(int order = 0) -> void
+ZeroAlloc.Mediator.Unit
+ZeroAlloc.Mediator.Unit.Equals(ZeroAlloc.Mediator.Unit other) -> bool
+ZeroAlloc.Mediator.Unit.Unit() -> void
+~override ZeroAlloc.Mediator.Unit.Equals(object obj) -> bool
+~override ZeroAlloc.Mediator.Unit.ToString() -> string

--- a/src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj
+++ b/src/ZeroAlloc.Mediator/ZeroAlloc.Mediator.csproj
@@ -8,5 +8,13 @@
   <ItemGroup>
     <PackageReference Include="ZeroAlloc.Pipeline" Version="$(ZeroAllocPipelineVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Adopts the public-API gating pattern from [ZeroAlloc.Authorization](https://github.com/ZeroAlloc-Net/ZeroAlloc.Authorization) for this repo. Phase A pilot of a family-wide rollout (Results landed first as #26).

## What's added
- `Microsoft.CodeAnalysis.PublicApiAnalyzers` analyzer + `PublicAPI.Shipped.txt` (empty) / `PublicAPI.Unshipped.txt` (current public surface, 27 symbols)
- `RS0016` (new public symbol not declared) and `RS0017` (declared symbol removed) elevated to errors via `Directory.Build.props`
- `api-compat` CI job comparing current build against latest published 1.x — actively gates against `1.1.8`

## What this gates
- Adding a new public symbol without recording it in `PublicAPI.Unshipped.txt` -> compile error
- Removing or renaming a previously-declared symbol -> compile error
- Future binary-incompat changes between 1.x patches -> CI failure

## At next 1.x release
After the next 1.x publishes, move `PublicAPI.Unshipped.txt` content to `PublicAPI.Shipped.txt`.

## Test plan
- [ ] `dotnet build -c Release` clean
- [ ] `dotnet test -c Release` passes
- [ ] CI all green: `lint-commits`, `build`, `aot-smoke` (if exists), `api-compat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)