### PR TITLE
feat!: signal 4.0 major release + fix release-please mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
       - name: Verify generator pack layout
         run: bash scripts/verify-generator-pack-layout.sh ./artifacts
 
-      - name: Push to NuGet (pre-release)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
   aot-smoke:
     runs-on: ubuntu-latest
     # Publishes samples/ZeroAlloc.Mediator.AotSmoke with PublishAot=true and runs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,12 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
+          # Manifest mode: read release-please-config.json + .release-please-manifest.json
+          # from the repo root. Single-package mode (release-type passed inline) ignores
+          # those files and tracks state via PR labels — which got into a corrupted state
+          # producing wrong version PRs (2.0.1 against feat! commits). See #65.
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:


### PR DESCRIPTION
## TL;DR

Adds the `feat!` signal release-please needs to bump to **4.0.0** (PR #63's squash subject was just `feat:` so release-please saw a minor bump → 3.1.0, which is already taken on NuGet). Plus the structural fixes that prevent this from happening again.

## Changes

### 1. Empty marker commit `feat!: signal 4.0 major release`
Carries `BREAKING CHANGE:` footer documenting #63's actual breakage. Without this, release-please sees the squash-merged `feat: 3.0 di integration (#63)` (no `!`) and computes 3.0.0 + minor → 3.1.0.

### 2. Stop ci.yml auto-publishing on every main push
`ci.yml` had `Push to NuGet (pre-release)` running on every main push using GitVersion's auto-computed version. Despite the name, it published stable versions: `2.2.0` (PR #63 — feat! commits as a *minor* bump, SemVer violation) and `3.1.0` (PR #65, same content + config). Both are now unlisted but the slots are consumed.

### 3. Switch release-please to manifest mode
The action was running with `release-type: simple` inline, which **ignores** `release-please-config.json` / `.release-please-manifest.json` and tracks state via PR labels. That's why #65's manifest fix had no effect. Switching to `config-file` + `manifest-file` makes release-please read the on-disk files (manifest = `3.0.0`).

## After merge

release-please reads:
- Manifest: `3.0.0`
- New commits since `v3.0.0` tag: includes a `feat!:` with `BREAKING CHANGE:` → major bump
- Computes: **4.0.0**

A fresh release PR titled `release 4.0.0` will open. Merging it creates `v4.0.0` tag + GitHub release + publishes 4.0.0 to NuGet via the `publish` job (which only runs when release-please created a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)