### PR TITLE
ci(release-please): use RELEASE_PLEASE_TOKEN to trigger downstream CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
           # producing wrong version PRs (2.0.1 against feat! commits). See #65.
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish:
     needs: release-please


### PR DESCRIPTION
Replaces `GITHUB_TOKEN` with org PAT secret `RELEASE_PLEASE_TOKEN` so release-please PRs trigger the `build` workflow (GITHUB_TOKEN-created PRs/pushes don't trigger workflows by design, which leaves release PRs blocked by the required `build` status check).