### PR TITLE
fix(ci): include Mediator.Authorization in release publish + add manifest-driven rescue

### DIFF
--- a/.github/workflows/publish-from-manifest.yml
+++ b/.github/workflows/publish-from-manifest.yml
@@ -1,0 +1,69 @@
+name: Publish from manifest
+
+# Manually-triggered rescue workflow that packs and pushes every src/ project
+# at the version recorded in .release-please-manifest.json. Designed for the
+# case where release-please created the GitHub release/tag but the publish job
+# missed a sub-package (e.g. the hardcoded pack list in release-please.yml is
+# stale and a new sub-package is missing). --skip-duplicate makes re-runs safe.
+#
+# Walks ZeroAlloc.Mediator.slnx for every src/* csproj — no hardcoded list,
+# survives sub-package additions automatically.
+#
+# Usage:  gh workflow run publish-from-manifest.yml --repo ZeroAlloc-Net/ZeroAlloc.Mediator
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Read manifest version
+        id: version
+        run: |
+          version=$(jq -r '.["."]' .release-please-manifest.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Manifest version: $version"
+
+      - name: Restore
+        run: dotnet restore ZeroAlloc.Mediator.slnx
+
+      - name: Build
+        run: dotnet build ZeroAlloc.Mediator.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test ZeroAlloc.Mediator.slnx --configuration Release --no-build
+
+      - name: Pack every src/* csproj
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mkdir -p ./nupkg
+          # Walk src/*/*.csproj — pack every project, NuGet's --skip-duplicate
+          # makes the push idempotent so already-published versions are no-ops.
+          # Test/sample/benchmark projects don't live under src/ so they're
+          # naturally excluded.
+          for csproj in src/*/*.csproj; do
+            echo "Packing $csproj at version $VERSION"
+            dotnet pack "$csproj" -c Release --no-build \
+              -p:PackageVersion="$VERSION" -o ./nupkg
+          done
+          ls -la ./nupkg
+
+      - name: Push to NuGet
+        run: |
+          dotnet nuget push ./nupkg/*.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,7 @@ jobs:
           dotnet pack src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Mediator.Telemetry/ZeroAlloc.Mediator.Telemetry.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Problem

The release-please publish job's \`Pack\` step (`release-please.yml:51-56`) hardcoded 6 sub-packages — Mediator, Generator, Cache, Validation, Resilience, Telemetry. The new \`Mediator.Authorization\` sub-package introduced in #74 was never added to that list, so v4.1.0 shipped to **GitHub releases** but not to **NuGet**.

Confirmed in the v4.1.0 publish job log: 6 .nupkg files packed and pushed, no Authorization. The other 6 packages are now on NuGet at 4.1.0; \`ZeroAlloc.Mediator.Authorization\` does not exist on NuGet at any version.

## Fix

**Two changes:**

1. **`release-please.yml`**: add the missing pack line for \`src/ZeroAlloc.Mediator.Authorization/...\` so future v4.x.y releases include it.

2. **`publish-from-manifest.yml`** (new): manually-triggered rescue workflow that walks \`src/*/*.csproj\` and packs every project at the version in \`.release-please-manifest.json\`. \`--skip-duplicate\` makes re-runs safe. Same pattern as in \`ZeroAlloc.Saga\` and \`ZeroAlloc.Specification\` repos.

Three benefits to the rescue workflow:
- Backfills the missing 4.1.0 publish of \`Mediator.Authorization\` manually after merge.
- Future sub-package additions don't need a release-please.yml edit — the manifest-driven walk picks them up automatically.
- Provides recovery path for any future partial-publish failure without needing a fresh release-please cycle.

## After merge

```bash
gh workflow run publish-from-manifest.yml --repo ZeroAlloc-Net/ZeroAlloc.Mediator
```

…to push \`ZeroAlloc.Mediator.Authorization 4.1.0\` to NuGet.

## Test plan

- [ ] CI green (lint-commits, build, aot-smoke, api-compat)
- [ ] After merge, run the rescue workflow and verify \`curl https://api.nuget.org/v3-flatcontainer/zeroalloc.mediator.authorization/index.json\` returns \`["4.1.0"]\` within 15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)