### PR TITLE
chore(renovate): skip EFCore major bumps until net8.0 drops

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,29 @@
   "extends": [
     "config:recommended"
   ],
-  "schedule": ["before 6am on monday"],
+  "schedule": [
+    "before 6am on monday"
+  ],
   "timezone": "Europe/Amsterdam",
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies"
+  ],
   "packageRules": [
     {
-      "description": "Ignore internal ZeroAlloc packages — managed by release-please",
-      "matchPackagePrefixes": ["ZeroAlloc."],
+      "description": "Skip EFCore major bumps \u2014 EFCore 10 dropped net8.0 support; pin via Directory.Packages.props per-TFM until we drop net8.0.",
+      "matchPackagePrefixes": [
+        "Microsoft.EntityFrameworkCore"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Ignore internal ZeroAlloc packages \u2014 managed by release-please",
+      "matchPackagePrefixes": [
+        "ZeroAlloc."
+      ],
       "enabled": false
     },
     {
@@ -25,27 +41,37 @@
     },
     {
       "description": "Group xunit packages",
-      "matchPackagePrefixes": ["xunit"],
+      "matchPackagePrefixes": [
+        "xunit"
+      ],
       "groupName": "xunit"
     },
     {
       "description": "Group Microsoft.Extensions packages",
-      "matchPackagePrefixes": ["Microsoft.Extensions."],
+      "matchPackagePrefixes": [
+        "Microsoft.Extensions."
+      ],
       "groupName": "Microsoft.Extensions"
     },
     {
       "description": "Group Microsoft.CodeAnalysis packages",
-      "matchPackagePrefixes": ["Microsoft.CodeAnalysis."],
+      "matchPackagePrefixes": [
+        "Microsoft.CodeAnalysis."
+      ],
       "groupName": "Microsoft.CodeAnalysis"
     },
     {
       "description": "Group GitHub Actions",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "GitHub Actions"
     },
     {
       "description": "Automerge patch updates",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "automerge": true
     }
   ]


### PR DESCRIPTION
Adds a Renovate rule disabling **major** version updates for `Microsoft.EntityFrameworkCore.*` packages.\n\nWhy: EFCore 10 dropped net8.0 support. While this library still multi-targets net8.0, the only way to consume EFCore 10 is per-TFM pinning in `Directory.Packages.props`. Without this rule, Renovate keeps proposing the v10 unification and breaks restore on every cycle.\n\nMinor and patch updates (e.g., security fixes) continue to flow normally.