### PR TITLE
fix(readme): absolute GitHub URLs so nuget.org links resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ZeroAlloc.Mediator is **40–160x faster** than MediatR with **zero heap allocat
 | Publish (multi handler) | 6.6 ns | 332.4 ns | ~51x | 0 B vs 1,032 B |
 | Stream (5 items) | 202.8 ns | 654.4 ns | ~3x | 104 B vs 528 B |
 
-See [docs/performance.md](docs/performance.md) for the full benchmark table and zero-allocation design explanation.
+See [docs/performance.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/performance.md) for the full benchmark table and zero-allocation design explanation.
 
 ## Features
 
@@ -78,17 +78,17 @@ See [docs/performance.md](docs/performance.md) for the full benchmark table and 
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](docs/getting-started.md) | Install and send your first request in five minutes |
-| [Requests & Handlers](docs/requests.md) | Commands, queries, `Unit` responses, dispatch |
-| [Notifications](docs/notifications.md) | Events: sequential, parallel, polymorphic handlers |
-| [Streaming](docs/streaming.md) | `IAsyncEnumerable<T>` for large result sets |
-| [Pipeline Behaviors](docs/pipeline-behaviors.md) | Compile-time middleware: logging, validation, caching |
-| [Authorization](docs/authorization.md) | `[Authorize]`-gated dispatch via `ZeroAlloc.Authorization` policies |
-| [Dependency Injection](docs/dependency-injection.md) | DI containers, `IMediator`, factory delegates |
-| [Diagnostics](docs/diagnostics.md) | ZAM001–ZAM007 compiler error reference with fixes |
-| [Performance](docs/performance.md) | Zero-alloc internals, benchmark results, Native AOT |
-| [Advanced Patterns](docs/advanced.md) | Error handling, cancellation, scoped behaviors |
-| [Testing](docs/testing.md) | Unit-test handlers, behaviors, and notifications |
+| [Getting Started](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/getting-started.md) | Install and send your first request in five minutes |
+| [Requests & Handlers](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/requests.md) | Commands, queries, `Unit` responses, dispatch |
+| [Notifications](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/notifications.md) | Events: sequential, parallel, polymorphic handlers |
+| [Streaming](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/streaming.md) | `IAsyncEnumerable<T>` for large result sets |
+| [Pipeline Behaviors](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/pipeline-behaviors.md) | Compile-time middleware: logging, validation, caching |
+| [Authorization](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/authorization.md) | `[Authorize]`-gated dispatch via `ZeroAlloc.Authorization` policies |
+| [Dependency Injection](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/dependency-injection.md) | DI containers, `IMediator`, factory delegates |
+| [Diagnostics](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/diagnostics.md) | ZAM001–ZAM007 compiler error reference with fixes |
+| [Performance](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/performance.md) | Zero-alloc internals, benchmark results, Native AOT |
+| [Advanced Patterns](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/advanced.md) | Error handling, cancellation, scoped behaviors |
+| [Testing](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/testing.md) | Unit-test handlers, behaviors, and notifications |
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrite all relative links in `README.md` to absolute GitHub URLs. The README ships to nuget.org via `<PackageReadmeFile>`; nuget.org renders it in its own host context, so any `[text](docs/foo.md)` style links 404 on the package page today.

## Pattern

- File links: `[text](path)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/blob/main/path)`
- Directory links: `[text](path/)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/tree/main/path/)`
- Image links: `![alt](img.png)` -> `![alt](https://raw.githubusercontent.com/ZeroAlloc-Net/<repo>/main/img.png)` (raw host so the image renders inline)
- Anchors (`#section`) and already-absolute URLs (`https://...`) unchanged
- `#anchor` fragments preserved on rewritten file links

## Verification

`README.md` still renders cleanly on the GitHub repo page (absolute self-references work in GitHub's renderer too). Once merged, the next NuGet release publishes the updated README and nuget.org links will resolve to the actual files.

Generated with [Claude Code](https://claude.com/claude-code)
