### PR TITLE
docs(performance): add BENCH sentinels for template import

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -78,6 +78,7 @@ For I/O-bound handlers that do suspend, `ValueTask` still reduces overhead compa
 
 Benchmarks run with BenchmarkDotNet on .NET 10, Release build, 12th Gen Intel Core i9-12900HK. Full benchmark source in `tests/ZeroAlloc.Mediator.Benchmarks/`.
 
+<!-- BENCH:START -->
 | Method | ZeroAlloc.Mediator | MediatR | Ratio | ZA Alloc | MediatR Alloc |
 |---|---:|---:|---:|---:|---:|
 | Send | 0.5 ns | 78.3 ns | **~160×** | 0 B | 224 B |
@@ -89,6 +90,7 @@ Benchmarks run with BenchmarkDotNet on .NET 10, Release build, 12th Gen Intel Co
 | Stream (5 items) | 202.8 ns | 654.4 ns | **~3×** | 104 B | 528 B |
 
 ZeroAlloc.Mediator is **40–160× faster** than MediatR across all measured paths, with zero heap allocations on every non-streaming path.
+<!-- BENCH:END -->
 
 ## Dispatch Comparison
 


### PR DESCRIPTION
## Summary
- Wraps the vs-MediatR comparison table in `docs/performance.md` with `<!-- BENCH:START -->` / `<!-- BENCH:END -->` markers.
- Enables ZeroAlloc.Templates' `tools/import-comparisons.ps1` to pull these numbers verbatim into the aggregated docs site.

## Why
ZA.Mediator already publishes a full vs-MediatR comparison (40–160× faster, 0 B alloc). The template's `docs/za-clean.md` has a `MEDIATOR` sentinel block currently rendering a "deferred" placeholder. Adding the BENCH markers here is half of the wire-up; the other half is a follow-up PR against `ZeroAlloc.Templates`.

## Test plan
- [x] Sentinels are HTML comments — invisible on GitHub render.
- [x] No content changes to the table itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)