### PR TITLE
build(authorization.generator): publish as its own nupkg

### DIFF
--- a/src/ZeroAlloc.Mediator.Authorization.Generator/ZeroAlloc.Mediator.Authorization.Generator.csproj
+++ b/src/ZeroAlloc.Mediator.Authorization.Generator/ZeroAlloc.Mediator.Authorization.Generator.csproj
@@ -4,11 +4,22 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>ZeroAlloc.Mediator.Authorization.Generator</RootNamespace>
-    <IsPackable>false</IsPackable>
+    <PackageId>ZeroAlloc.Mediator.Authorization.Generator</PackageId>
+    <Description>Roslyn source generator for ZeroAlloc.Mediator.Authorization. Discovers [AuthorizationPolicy]-decorated types in the consumer's compilation and emits the per-request policy lookup table the authorization behavior uses at runtime.</Description>
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- RS2008: analyzer release tracking is opt-in; we don't ship a public AnalyzerReleases.* manifest. -->
     <NoWarn>$(NoWarn);RS2008</NoWarn>
+
+    <!--
+      Source-generator packaging: ship the generator DLL under analyzers/dotnet/cs so
+      Roslyn loads it as an analyzer in consumer projects. Without IncludeBuildOutput=false
+      the build output ends up under lib/ and consumers silently get no source generator.
+      Mirrors the pattern in ZeroAlloc.Mediator.Generator and ZeroAlloc.Validation.Generator.
+    -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
@@ -16,5 +27,23 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ZeroAlloc.Mediator.Authorization.Generator.Tests" />
+  </ItemGroup>
+
+  <!--
+    Pack the generator DLL under analyzers/dotnet/cs. Without this block, dotnet pack
+    falls back to the default lib/<tfm>/ layout and consumers do not pick up the
+    generator at all (the symptom: [AuthorizationPolicy] types compile but the policy
+    lookup is never populated, so every request denies with "no policy registered for X").
+  -->
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"
+          Condition="Exists('$(OutputPath)\$(AssemblyName).pdb')" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
\`ZeroAlloc.Mediator.Authorization.Generator\` had \`IsPackable=false\`. The generator built locally for the repo's tests but the published \`ZeroAlloc.Mediator.Authorization\` nupkg shipped without it. Consumers adding the bridge package got the \`AuthorizationBehavior\` + attributes but no source-generated policy lookup, so every authorized request would fall through with an empty registry.

**Same shape as the recent ZA.Validation.Generator publishing fix** (ZA.Validation#37).

## Fix
Mirrors the \`ZA.Mediator.Generator\` / \`ZA.Validation.Generator\` pattern:
- Remove \`IsPackable=false\`
- Add standard analyzer-packaging metadata: \`IncludeBuildOutput=false\`, \`SuppressDependenciesWhenPacking=true\`, \`DevelopmentDependency=true\`
- Add \`PackageId\` + \`Description\`
- Pack the generator DLL + PDB under \`analyzers/dotnet/cs/\`

## Verified locally
\`dotnet pack\` produces:
\`\`\`
analyzers/dotnet/cs/ZeroAlloc.Mediator.Authorization.Generator.dll
analyzers/dotnet/cs/ZeroAlloc.Mediator.Authorization.Generator.pdb
\`\`\`

All 40 authorization tests pass (29 in \`.Tests\` + 11 in \`.Generator.Tests\`).

## Auto-publish
The existing \`publish-from-manifest.yml\` workflow walks \`src/*/*.csproj\`. The new package will publish automatically on the next release-please version bump.

## Discovery context
Surfaced while wiring \`ZA.Mediator.Authorization\` into the \`ZA.Templates\` \`za-clean\` template — exact same diagnostic the ZA.Validation fix surfaced (NU1101: package not found for the \`.Generator\` reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)