### PR TITLE
docs(perf): clarify Stream 104 B is compiler state machine, not ZA overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ZeroAlloc.Mediator is **40–160x faster** than MediatR with **zero heap allocat
 | Publish (multi handler) | 6.6 ns | 332.4 ns | ~51x | 0 B vs 1,032 B |
 | Stream (5 items) | 202.8 ns | 654.4 ns | ~3x | 104 B vs 528 B |
 
-See [docs/performance.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/performance.md) for the full benchmark table and zero-allocation design explanation.
+The 104 B on the Stream row is the C# compiler's `async IAsyncEnumerable<T>` state machine for your handler method — every mediator dispatching to such handlers pays this; ZA.Mediator's own stream-dispatch contribution is 0 B. See [docs/performance.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/blob/main/docs/performance.md) for the full benchmark table and zero-allocation design explanation.
 
 ## Features
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -90,6 +90,8 @@ Benchmarks run with BenchmarkDotNet on .NET 10, Release build, 12th Gen Intel Co
 | Stream (5 items) | 202.8 ns | 654.4 ns | **~3×** | 104 B | 528 B |
 
 ZeroAlloc.Mediator is **40–160× faster** than MediatR across all measured paths, with zero heap allocations on every non-streaming path.
+
+**Stream allocation source.** The 104 B on the ZA Stream row is the C# compiler's `async IAsyncEnumerable<T>` state-machine allocation for the user's handler method (e.g. `async IAsyncEnumerable<int> Handle(...) { yield return ...; }`). Any mediator dispatching to such handlers pays this cost — MediatR pays it *on top of* its own ~424 B wrapper. ZA.Mediator's own stream-dispatch contribution is 0 B. .NET 10 has no pooled state-machine builder for `async IAsyncEnumerable<T>` (unlike `ValueTask` with `[AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]`); the only way to drop below 104 B is to implement `IAsyncEnumerable<T>` by hand without `yield return`.
 <!-- BENCH:END -->
 
 ## Dispatch Comparison


### PR DESCRIPTION
## Summary

Reframes the \`104 B\` on ZA.Mediator's Stream row as **C# compiler-generated \`async IAsyncEnumerable<T>\` state machine** for the user's handler method — not ZA.Mediator overhead. Investigation of the sweep backlog item turned up:

- ZA.Mediator's \`CreateStream\` emit allocates 0 B on top of the handler call.
- The user's \`async IAsyncEnumerable<int> Handle(...)\` method is compiled to a state-machine class allocated on each call (~104 B).
- Any mediator dispatching to such handlers pays this; MediatR's 528 B = the same state machine + ~424 B of its own wrapping.
- .NET 10 has no pooled state-machine builder for \`async IAsyncEnumerable<T>\` (unlike \`ValueTask\` with \`PoolingAsyncValueTaskMethodBuilder\`). Only way to drop below 104 B is hand-rolled \`IAsyncEnumerable<T>\` without \`yield return\` — out of scope for ZA.Mediator's generator to mandate.

The fix is narrative, not code. New paragraph in \`docs/performance.md\` (inside the existing \`<!-- BENCH:START -->\` block so the ZA.Templates aggregator picks it up automatically); one-sentence README addition pointing readers to the full explanation.

## Test plan

- [x] Re-read both docs after edit — narrative reads cleanly, doesn't contradict the table
- [ ] CI green