### PR TITLE
ci: walk per-component manifest versions in publish-from-manifest

### DIFF
--- a/.github/workflows/publish-from-manifest.yml
+++ b/.github/workflows/publish-from-manifest.yml
@@ -6,8 +6,12 @@ name: Publish from manifest
 # missed a sub-package (e.g. the hardcoded pack list in release-please.yml is
 # stale and a new sub-package is missing). --skip-duplicate makes re-runs safe.
 #
-# Walks ZeroAlloc.Mediator.slnx for every src/* csproj — no hardcoded list,
-# survives sub-package additions automatically.
+# Per-component versioning: each src/*/*.csproj is packed at the version
+# from the LONGEST matching manifest key prefix. Example:
+#   src/ZeroAlloc.Mediator.Authorization/X.csproj  -> uses key "src/ZeroAlloc.Mediator.Authorization"
+#   src/ZeroAlloc.Mediator/X.csproj                -> falls back to key "."
+# This survives release-please's multi-package manifest split (where the
+# Authorization extension versions independently from Mediator core).
 #
 # Usage:  gh workflow run publish-from-manifest.yml --repo ZeroAlloc-Net/ZeroAlloc.Mediator
 
@@ -29,13 +33,6 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Read manifest version
-        id: version
-        run: |
-          version=$(jq -r '.["."]' .release-please-manifest.json)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Manifest version: $version"
-
       - name: Restore
         run: dotnet restore ZeroAlloc.Mediator.slnx
 
@@ -45,19 +42,33 @@ jobs:
       - name: Test
         run: dotnet test ZeroAlloc.Mediator.slnx --configuration Release --no-build
 
-      - name: Pack every src/* csproj
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
+      - name: Pack every src/* csproj at its per-component manifest version
         run: |
           mkdir -p ./nupkg
-          # Walk src/*/*.csproj — pack every project, NuGet's --skip-duplicate
-          # makes the push idempotent so already-published versions are no-ops.
-          # Test/sample/benchmark projects don't live under src/ so they're
-          # naturally excluded.
+          # For each src/*/*.csproj, resolve its version from the manifest by
+          # finding the longest manifest key that is a prefix of the project's
+          # directory. Falls back to the root "." key when no sub-component
+          # matches. --skip-duplicate at push time makes the workflow idempotent.
           for csproj in src/*/*.csproj; do
-            echo "Packing $csproj at version $VERSION"
+            proj_dir=$(dirname "$csproj")
+            best_match="."
+            for key in $(jq -r 'keys[]' .release-please-manifest.json); do
+              if [ "$key" = "." ]; then
+                continue
+              fi
+              # Match if proj_dir starts with key followed by / or end of string
+              case "$proj_dir" in
+                "$key"|"$key"/*)
+                  if [ "${#key}" -gt "${#best_match}" ] || [ "$best_match" = "." ]; then
+                    best_match="$key"
+                  fi
+                  ;;
+              esac
+            done
+            version=$(jq -r --arg k "$best_match" '.[$k]' .release-please-manifest.json)
+            echo "Packing $csproj at version $version (manifest key: '$best_match')"
             dotnet pack "$csproj" -c Release --no-build \
-              -p:PackageVersion="$VERSION" -o ./nupkg
+              -p:PackageVersion="$version" -o ./nupkg
           done
           ls -la ./nupkg
 


### PR DESCRIPTION
## Summary

The `publish-from-manifest` rescue workflow read only the root `.` version from `.release-please-manifest.json` and packed every `src/*/*.csproj` at that single version. With release-please's split-versioning config (Authorization versions independently from core), this caused the Authorization sub-package to be packed at `4.1.4` (core version) instead of `2.0.0`, so `--skip-duplicate` silently no-op'd every push.

This blocked the v2.0.0 publish for `ZeroAlloc.Mediator.Authorization` — even after PR #90 (release-please) merged and recorded `2.0.0` for the Authorization key, the publish workflow couldn't read that key.

## Fix

Walk each `src/*/*.csproj`, resolve its version by finding the **longest manifest key** that is a prefix of the project's directory. Falls back to root `.` when no sub-component matches.

```
src/ZeroAlloc.Mediator.Authorization/X.csproj
  -> manifest key "src/ZeroAlloc.Mediator.Authorization" -> 2.0.0

src/ZeroAlloc.Mediator/X.csproj
  -> falls back to "." -> 4.1.4

src/ZeroAlloc.Mediator.Validation/X.csproj
  -> falls back to "." -> 4.1.4 (no separate manifest entry)
```

Pure bash (uses `jq` already on the runner). No new dependencies. Survives any future per-component splits without further workflow edits.

## Test plan

- [ ] **After merge**, manually trigger this workflow: `gh workflow run "Publish from manifest" --repo ZeroAlloc-Net/ZeroAlloc.Mediator --ref main`
- [ ] Workflow log should show `Packing src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj at version 2.0.0 (manifest key: 'src/ZeroAlloc.Mediator.Authorization')`
- [ ] `ZeroAlloc.Mediator.Authorization 2.0.0` appears on NuGet shortly after

## Context

This is the third PR in the v2.0.0 publish recovery chain:
- #87: original Mediator.Authorization v2 changes (merged)
- #88: release-please's mis-bump to 5.0.0/3.0.0 (merged then reverted)
- #89: revert + release-as overrides to recover (merged)
- #90: release-please's correct release PR for authorization-v2.0.0 (merged, but didn't trigger publish because of the bug this PR fixes)
- **#91 (this)**: fix the publish workflow itself