### PR TITLE
chore(release): drop one-shot release-as overrides (mediator + authorization)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,16 +5,13 @@
       "release-type": "simple",
       "package-name": "ZeroAlloc.Mediator",
       "component": "mediator",
-      "include-component-in-tag": false,
-      "release-as": "4.1.4"
+      "include-component-in-tag": false
     },
     "src/ZeroAlloc.Mediator.Authorization": {
       "release-type": "simple",
       "package-name": "ZeroAlloc.Mediator.Authorization",
       "component": "authorization",
-      "include-component-in-tag": true,
-      "initial-version": "2.0.0",
-      "release-as": "2.0.0"
+      "include-component-in-tag": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Drops three lingering release-please config knobs that have served their purpose:

- `.` package: `\"release-as\": \"4.1.4\"` — was used in [#89](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/pull/89) to recover from a release-please miscomputation that produced a 5.0.0 bump after [#87](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/pull/87)'s squash-merge attributed `feat!:` commits to both core and authorization via path routing.
- `src/ZeroAlloc.Mediator.Authorization`: `\"release-as\": \"2.0.0\"` — same PR steered Authorization to its intended major bump.
- `src/ZeroAlloc.Mediator.Authorization`: `\"initial-version\": \"2.0.0\"` — bootstrap value, only applies on first manifest entry; 2.0.0 is already recorded.

Both versions have shipped to NuGet. Every release-please run since has been a no-op (the override version matches the manifest version) and blocks conventional-commit-driven bumps from proceeding. Drop them so the next real `feat:` / `fix:` touching either component bumps as expected.

## Test plan

- [ ] CI green (config syntax + lint)
- [ ] Next conventional-commit bump actually moves the version (validated on first post-merge release-please run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)