### PR TITLE
test: Mediator.Authorization integration tests + AOT smoke restructure (backlog #4-#7)

### DIFF
--- a/docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md
+++ b/docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md
@@ -46,45 +46,75 @@ should disappear once the smoke uses the public surface only (backlog #7).
 
 ### Test fixture (`tests/ZeroAlloc.Mediator.Authorization.Tests/IntegrationTests.cs`)
 
+**Critical constraint — cross-assembly pipeline-behavior wiring.** The Mediator source generator discovers pipeline behaviors by scanning `[PipelineBehavior]`-decorated types in the **current compilation only**. `AuthorizationBehavior` lives in `ZeroAlloc.Mediator.Authorization` (a separate assembly) and therefore is invisible to the generator running in the test assembly. The existing `AuthorizationBehaviorTests.cs` calls `AuthorizationBehavior.Handle` directly and explicitly opts out of `IMediator`-driven integration for this reason.
+
+To run an `IMediator.Send` integration test, the test assembly needs a **local shim behavior** that the generator can see. The shim implements the marker `IPipelineBehavior` interface, carries the `[PipelineBehavior(Order = -1000)]` attribute, and its static `Handle<TRequest, TResponse>` method just forwards to `AuthorizationBehavior.Handle`. The pipeline-ordering counter behavior follows the same pattern (local class, `[PipelineBehavior(Order = -500)]`, static `Handle`).
+
+`ZeroAlloc.Mediator` pipeline behaviors are NOT a generic-class shape (`IPipelineBehavior<TReq, TResp>`). The interface is a non-generic marker; behaviors are sealed classes with a STATIC `Handle<TRequest, TResponse>` generic method, decorated at class-level with `[PipelineBehavior(Order = N)]`.
+
 Single new file. Shared types used by all three new tests:
 
 ```csharp
-[Policy("TestPolicy")]
-public sealed class TestPolicy : IAuthorizationPolicy { ... }
-
-[RequirePolicy("TestPolicy")]
-public sealed record TestRequest(int Value) : IRequest<TestResponse>;
-public sealed record TestResponse(int Echo);
-
-internal sealed class TestHandler : IRequestHandler<TestRequest, TestResponse>
+[Policy("IntegrationTestPolicy")]
+public sealed class IntegrationTestPolicy : IAuthorizationPolicy
 {
-    public Task<TestResponse> Handle(TestRequest req, CancellationToken ct)
-        => Task.FromResult(new TestResponse(req.Value));
+    // Allow when the security context carries the "Admin" role; deny otherwise.
+    public ValueTask<UnitResult<AuthorizationFailure>> EvaluateAsync(
+        ISecurityContext ctx, CancellationToken ct = default)
+        => new(ctx.Roles.Contains("Admin")
+            ? UnitResult<AuthorizationFailure>.Success()
+            : new AuthorizationFailure(AuthorizationFailure.DefaultDenyCode, "needs Admin"));
 }
 
-internal sealed class FakeSecurityContextAccessor : ISecurityContextAccessor
+[RequirePolicy("IntegrationTestPolicy")]
+public sealed record IntegrationTestRequest(int Value) : IRequest<int>;
+
+internal sealed class IntegrationTestHandler : IRequestHandler<IntegrationTestRequest, int>
 {
-    // AsyncLocal so future xUnit collection-level parallelism doesn't bleed
-    // claims across tests. Set per-test via SetClaims(...).
-    private static readonly AsyncLocal<IReadOnlyDictionary<string, string>?> _current = new();
-    public ISecurityContext GetCurrent() => new TestSecurityContext(_current.Value ?? EmptyDict);
-    public static void SetClaims(IReadOnlyDictionary<string, string> claims) => _current.Value = claims;
+    public ValueTask<int> Handle(IntegrationTestRequest r, CancellationToken ct)
+        => ValueTask.FromResult(r.Value * 2);
 }
 
+// Local shim — the test-assembly's generator picks this up; the real
+// AuthorizationBehavior is invisible to it because it lives in a referenced
+// assembly. Same Order, identical contract, just forwards.
+[PipelineBehavior(Order = -1000)]
+public sealed class AuthorizationBehaviorShim : IPipelineBehavior
+{
+    public static ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request, CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+        => AuthorizationBehavior.Handle<TRequest, TResponse>(request, ct, next);
+}
+
+// Ordering stub: numerically AFTER Authorization (-1000 < -500). Counter
+// only ticks if this behavior actually runs in a given Send call.
 internal sealed class InvocationCounter { public int Count; }
 
-[PipelineBehavior(Order = -500)] // numerically AFTER Authorization (-1000)
-internal sealed class CountingDownstreamBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+[PipelineBehavior(Order = -500)]
+public sealed class CountingDownstreamBehavior : IPipelineBehavior
 {
-    private readonly InvocationCounter _counter;
-    public CountingDownstreamBehavior(InvocationCounter counter) => _counter = counter;
-    public Task<TResponse> Handle(TRequest req, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+    public static ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request, CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
     {
-        _counter.Count++;
-        return next();
+        AuthorizationBehaviorState.ServiceProvider!
+            .GetRequiredService<InvocationCounter>().Count++;
+        return next(request, ct);
     }
 }
+
+internal sealed class TestSecurityContextAccessor : ISecurityContextAccessor
+{
+    public ISecurityContext Current { get; set; } = AnonymousSecurityContext.Instance;
+}
 ```
+
+The `ISecurityContextAccessor` shape matches the existing test fixture (`TestFixtures.cs`); each test scopes its own provider with the accessor's `Current` set to the desired security context.
+
+The `CountingDownstreamBehavior` reads `AuthorizationBehaviorState.ServiceProvider` to resolve the counter — same trick as the existing tests (the test assembly has `InternalsVisibleTo`). This is acceptable in the test fixture; the IVT removal in #7 targets the smoke binary only.
 
 ### Test 1 — pipeline ordering (#4)
 
@@ -93,18 +123,17 @@ internal sealed class CountingDownstreamBehavior<TRequest, TResponse> : IPipelin
 public async Task Pipeline_ordering_authorization_runs_before_later_behaviors()
 {
     var counter = new InvocationCounter();
-    var sp = BuildContainer(services =>
-    {
-        services.AddSingleton(counter);
-        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(CountingDownstreamBehavior<,>));
-    });
-
-    FakeSecurityContextAccessor.SetClaims(EmptyDict); // no claims → TestPolicy denies
+    using var sp = BuildContainer(counter, AnonymousSecurityContext.Instance);
     var mediator = sp.GetRequiredService<IMediator>();
-    var result = await mediator.Send(new TestRequest(42));
 
-    Assert.Equal(0, counter.Count);  // proves ordering: downstream stub never ran
-    Assert.True(IsAuthDenial(result));
+    // IntegrationTestRequest's policy needs the Admin role; anonymous denies →
+    // AuthorizationDeniedException is thrown by the shim (forwards to real behavior).
+    await Assert.ThrowsAsync<AuthorizationDeniedException>(async () =>
+        await mediator.Send(new IntegrationTestRequest(42)));
+
+    // Proves ordering: downstream stub never ran because authorization
+    // short-circuited at Order -1000 before -500 fired.
+    Assert.Equal(0, counter.Count);
 }
 ```
 
@@ -113,10 +142,12 @@ Authorization runs first AND short-circuits on deny, the stub never fires
 → `counter.Count == 0`. If a future change inverts the ordering, the stub
 fires → assertion catches it.
 
-**Swap-test for the assertion's meaningfulness:** changing the stub's Order
-to `-2000` (numerically before Authorization) must make this test FAIL with
+**Swap-test for the assertion's meaningfulness:** temporarily changing
+`CountingDownstreamBehavior`'s attribute to `[PipelineBehavior(Order = -2000)]`
+(numerically before Authorization) must make this test FAIL with
 `counter.Count == 1`. Verified manually pre-merge and documented as a
-comment above the test.
+comment above the test class so a future maintainer can re-verify the
+assertion is meaningful.
 
 ### Test 2 — end-to-end allow path (#5)
 
@@ -124,14 +155,14 @@ comment above the test.
 [Fact]
 public async Task End_to_end_through_IMediator_Send_allow_path()
 {
-    var sp = BuildContainer(_ => { });
-    FakeSecurityContextAccessor.SetClaims(new Dictionary<string, string> { ["sub"] = "test-user" });
-
+    var counter = new InvocationCounter();
+    using var sp = BuildContainer(counter, TestSecurityContexts.With("Admin"));
     var mediator = sp.GetRequiredService<IMediator>();
-    var result = await mediator.Send(new TestRequest(42));
 
-    Assert.True(IsAllowedResult(result));
-    Assert.Equal(42, ExtractValue(result));  // handler actually invoked
+    var result = await mediator.Send(new IntegrationTestRequest(7));
+
+    Assert.Equal(14, result);    // handler invoked: 7 * 2
+    Assert.Equal(1, counter.Count);  // downstream stub also ran (allow path passes through)
 }
 ```
 
@@ -141,98 +172,164 @@ public async Task End_to_end_through_IMediator_Send_allow_path()
 [Fact]
 public async Task End_to_end_through_IMediator_Send_deny_path()
 {
-    var sp = BuildContainer(_ => { });
-    FakeSecurityContextAccessor.SetClaims(EmptyDict);
-
+    var counter = new InvocationCounter();
+    using var sp = BuildContainer(counter, AnonymousSecurityContext.Instance);
     var mediator = sp.GetRequiredService<IMediator>();
-    var result = await mediator.Send(new TestRequest(42));
 
-    Assert.True(IsAuthDenial(result));  // handler must NOT have run
+    await Assert.ThrowsAsync<AuthorizationDeniedException>(async () =>
+        await mediator.Send(new IntegrationTestRequest(7)));
+
+    Assert.Equal(0, counter.Count);  // handler must NOT have run
 }
 ```
+
+(Test 3 is structurally similar to Test 1 — the difference is that Test 1's
+purpose is to assert ordering; Test 3's purpose is to prove the full
+dispatcher chain handles deny semantics. Keeping both makes each test's
+intent explicit.)
 
 ### Shared container builder
 
 ```csharp
-private static ServiceProvider BuildContainer(Action<IServiceCollection> extra)
+private static ServiceProvider BuildContainer(InvocationCounter counter, ISecurityContext ctx)
 {
     var services = new ServiceCollection();
-    services.AddScoped<ISecurityContextAccessor, FakeSecurityContextAccessor>();
-    services.AddSingleton<IRequestHandler<TestRequest, TestResponse>, TestHandler>();
-    services.AddMediator().WithAuthorization(o => o.UseAccessor<FakeSecurityContextAccessor>());
-    extra(services);
+    services.AddZeroAllocAuthorization();
+    services.AddSingleton(counter);
+    services.AddScoped<ISecurityContextAccessor>(_ =>
+        new TestSecurityContextAccessor { Current = ctx });
+    services.AddMediator().WithAuthorization(o => o.UseAccessor<ISecurityContextAccessor>());
     return services.BuildServiceProvider();
 }
 ```
 
-The exact `IsAllowedResult` / `IsAuthDenial` / `ExtractValue` helpers mirror
-the shape the existing `AuthorizationBehaviorTests` use (typed-failure
-`Result<TResponse, AuthorizationFailure>` vs thrown denial), determined at
-coding time so the new tests read consistently with the existing suite.
+The shim's static `Handle` reads `AuthorizationBehaviorState.ServiceProvider`,
+which is set by `AuthorizationBehaviorAccessor` on first IServiceProvider
+build — same production path the existing tests rely on. The test fixture
+DOES use `InternalsVisibleTo` to access `AuthorizationBehaviorState` for
+the `CountingDownstreamBehavior` (to resolve the counter); this is
+acceptable in the test assembly. The IVT removal in item #7 targets the
+sample binary only.
 
 ### AOT smoke restructure (#6)
 
-`samples/ZeroAlloc.Mediator.AotSmoke/AuthorizedScenario.cs`:
+**Current state.** `samples/ZeroAlloc.Mediator.AotSmoke/Authorization/AuthorizedScenario.cs`
+already calls `AuthorizationBehavior.Handle<TRequest, TResponse>(...)` as a
+static (the behavior IS a sealed class with static `Handle`; there is no
+instance to construct). The `VerifyAllocationBudget` step measures
+`AuthorizationBehavior.Handle` at line 171-174 with a 512 B budget. That
+part of item #6 has already been completed during ongoing development.
+
+What remains is the redundant **second** allocation gate at lines 176-181
+that measures `policy.EvaluateAsync` directly:
 
 ```csharp
-// Setup (outside any gate; setup cost is irrelevant to allocation budgets):
-private readonly AuthorizationBehavior<TestRequest, TestResponse> _behavior;
-private readonly TestRequest _allowRequest = new(1);
-private readonly TestRequest _denyRequest = new(2);
-private readonly TestResponse _okResponse = new(99);
-private readonly RequestHandlerDelegate<TestResponse> _next;
-
-ctor:
-    _behavior = new AuthorizationBehavior<TestRequest, TestResponse>(/* policy registry, accessor */);
-    _next = () => Task.FromResult(_okResponse);
-    // Pre-build allow / deny security contexts so the gate measures Handle only.
-
-// Inside the allocation gate (replaces today's policy.EvaluateAsync gate):
-gate.Measure("authorized-allow-handle", () =>
-    _behavior.Handle(_allowRequest, _next, ct: default).GetAwaiter().GetResult());
-gate.Measure("authorized-deny-handle", () =>
-    _behavior.Handle(_denyRequest, _next, ct: default).GetAwaiter().GetResult());
+// Direct policy invocation — tightest budget (0 B/call) on v2's single-method
+// IAuthorizationPolicy.EvaluateAsync returning UnitResult<AuthorizationFailure>.
+IAuthorizationPolicy policy = new AotAdminPolicy();
+AllocationGate.AssertBudgetValueTask(0, 1000,
+    () => policy.EvaluateAsync(adminCtx),
+    "Policy.EvaluateAsync (AOT smoke allow)");
 ```
 
-No DI container, no dispatcher, no `AuthorizationBehaviorState` access. Just
-the behavior, the `RequestHandlerDelegate next`, and the security context.
+This certifies `ZeroAlloc.Authorization` (already certified in that repo's
+own AOT smoke), not Mediator.Authorization. Per backlog item #6's stated
+purpose ("the AOT-side gate's job is to certify Mediator.Authorization's
+runtime under the AOT runtime"), the policy gate is out of scope here and
+should be removed.
 
-**Allocation budgets:** start at the values used by the corresponding JIT
-unit tests (`Behavior_*Allow_ZeroAllocation` / `Behavior_*Deny_ZeroAllocation`,
-already passing). If the AOT runtime shows higher allocation than JIT, bump
-the AOT budget with an inline comment noting the AOT-vs-JIT delta.
+**Change.** Delete lines 176-181 from `AuthorizedScenario.VerifyAllocationBudget`.
+The Handle gate above stays unchanged.
+
+**Allocation budget for the kept Handle gate.** Already at 512 B / 1000
+iterations — set during the original gate addition; left alone unless the
+post-IVT-removal change (next subsection) shifts the path.
 
 ### `InternalsVisibleTo` removal (#7)
 
-After the smoke refactor, delete from
+**Why the IVT exists today.** `AuthorizedScenario.cs` sets
+`AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider` directly
+six times (lines 108, 119, 137, 150, 168). `AuthorizationBehaviorState` is
+`internal`; access only works via the IVT.
+
+**Why the static gets set in production.** `WithAuthorization()` registers
+`AddSingleton(sp => new AuthorizationBehaviorAccessor(sp))`. The accessor's
+constructor sets `AuthorizationBehaviorState.ServiceProvider = sp` as a
+side effect. The singleton is lazy — nothing resolves it eagerly — so the
+static stays null until some code path resolves `AuthorizationBehaviorAccessor`.
+The AotSmoke (and the existing test suite) bypass this by setting the
+static directly through the IVT.
+
+For the smoke to drop the IVT cleanly, it needs to resolve the accessor
+itself. The accessor is `internal`, so it must be promoted to `public`.
+
+**Public API change.** Promote both:
+
+```csharp
+namespace ZeroAlloc.Mediator.Authorization;
+
+// was: internal static class
+public static class AuthorizationBehaviorState
+{
+    // was: internal static
+    public static volatile IServiceProvider? ServiceProvider;
+}
+
+// was: internal sealed class
+public sealed class AuthorizationBehaviorAccessor
+{
+    // was: internal
+    public AuthorizationBehaviorAccessor(IServiceProvider serviceProvider) =>
+        AuthorizationBehaviorState.ServiceProvider = serviceProvider;
+}
+```
+
+Strictly additive PublicAPI change (no signature changes, no removals).
+Update `src/ZeroAlloc.Mediator.Authorization/PublicAPI.Unshipped.txt`:
+
+```
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorAccessor
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorAccessor.AuthorizationBehaviorAccessor(System.IServiceProvider! serviceProvider) -> void
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState
+static ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState.ServiceProvider -> System.IServiceProvider?
+static ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState.ServiceProvider.set -> void
+```
+
+(Exact lines mirror Roslyn's PublicApiAnalyzer-generated format.)
+
+**Smoke refactor — replace the six direct assignments.** Each
+`AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider` line
+becomes:
+
+```csharp
+// Triggers AuthorizationBehaviorAccessor's ctor side-effect:
+// sets AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider.
+_ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
+```
+
+The accessor is registered as `AddSingleton` against the root provider, so
+the first resolution caches it; subsequent scopes get the same instance.
+The static reflects whichever provider was passed into the first ctor call
+— for the smoke's use (one fresh `BuildProvider` per scenario), that's the
+correct per-scenario provider.
+
+**Then drop the IVT.** Delete from
 `src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj`:
 
 ```xml
 <InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />
 ```
 
-Validation: `dotnet build samples/ZeroAlloc.Mediator.AotSmoke/...` must
-succeed cleanly. If it fails, the smoke still touches internals — STOP and
-either make the symbol public (if safe) OR refactor the smoke. Do not
-reintroduce the IVT silently.
+The `InternalsVisibleTo Include="ZeroAlloc.Mediator.Authorization.Tests"`
+STAYS — the test fixture still uses the IVT for the
+`CountingDownstreamBehavior`'s counter access (see Section 2). That IVT is
+between two repo-internal projects; nothing leaks externally. Removing it
+is a separate refactor not in scope for this work.
 
-If `PublicAPI.Unshipped.txt` references the removed visibility, drop those
-lines.
-
-### Constructor accessibility risk
-
-If `AuthorizationBehavior<TRequest, TResponse>`'s constructor is `internal`
-(plausible since today the smoke constructs via internals), the refactor in
-Section 3 can't construct it directly without the IVT. In that case the fix
-splits:
-
-1. Promote the constructor to `public` (or add a `public static
-   CreateForTesting(...)` factory).
-2. Add the new symbol to `PublicAPI.Unshipped.txt`.
-3. Only then drop the IVT.
-
-This is a strictly additive PublicAPI change — no removals, no signature
-changes — so the SemVer impact is none.
+**Validation.** `dotnet build samples/ZeroAlloc.Mediator.AotSmoke/...` must
+succeed after the smoke refactor + IVT removal. `dotnet publish
+-p:PublishAot=true` on the smoke must also succeed and the allocation gates
+must still pass within budget.
 
 ## Testing
 
@@ -254,3 +351,7 @@ changes — so the SemVer impact is none.
 - Real `ZeroAlloc.Mediator.Validation` integration test — explicitly
   rejected during brainstorming (B over A on test approach): the stub
   approach decouples this test from the Validation package's behavior.
+- Removing the `InternalsVisibleTo "ZeroAlloc.Mediator.Authorization.Tests"`
+  entry. Tests still use the IVT for the counter behavior's
+  `AuthorizationBehaviorState` access. The IVT to the smoke is the leak
+  that matters; tests are first-party and stay coupled.

--- a/docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md
+++ b/docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md
@@ -1,0 +1,256 @@
+# Mediator.Authorization integration tests + AOT smoke restructure
+
+Date: 2026-05-22
+Status: Approved
+Scope: backlog items #4 + #5 + #6 + #7
+
+## Problem
+
+`tests/ZeroAlloc.Mediator.Authorization.Tests/` covers `AuthorizationBehavior.Handle`
+in unit-test form: each test constructs the behavior, supplies a mocked
+`RequestHandlerDelegate next`, and asserts the policy/allow/deny logic. Two
+integration paths are uncovered:
+
+- **Pipeline ordering** (backlog #4). The behavior declares
+  `[PipelineBehavior(Order = -1000)]` so authorization runs before
+  validation / cache / logging. The constant is asserted in source, but no
+  test proves the ordering takes effect end-to-end. A future refactor of
+  Mediator's pipeline-ordering algorithm could break the assumed invariant
+  invisibly.
+- **End-to-end dispatch via `IMediator.Send`** (backlog #5). Today's tests
+  bypass the generator-emitted `[ModuleInitializer]` wiring and the DI /
+  dispatcher routing. The unit-level paths work; the integration is
+  unverified.
+
+Separately, the AOT smoke binary's allocation gate calls
+`policy.EvaluateAsync(ctx)` directly — that measures `ZeroAlloc.Authorization`
+(already certified upstream), not Mediator.Authorization's wiring. The
+behavior's allocation profile under AOT is unverified (backlog #6). The
+smoke accesses `AuthorizationBehaviorState.ServiceProvider` via
+`<InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />`, a leak that
+should disappear once the smoke uses the public surface only (backlog #7).
+
+## Goals
+
+- Add integration tests that prove pipeline ordering (deny short-circuits
+  before later behaviors fire) and that `IMediator.Send` exercises the full
+  wiring (allow + deny path).
+- Restructure the AOT smoke to measure `AuthorizationBehavior.Handle`
+  allocation instead of the underlying policy library.
+- Remove `InternalsVisibleTo "ZeroAlloc.Mediator.AotSmoke"` from the
+  Mediator.Authorization csproj.
+- Stay scoped to Mediator.Authorization. Do not pull in
+  `ZeroAlloc.Mediator.Validation` as a test dependency.
+
+## Design
+
+### Test fixture (`tests/ZeroAlloc.Mediator.Authorization.Tests/IntegrationTests.cs`)
+
+Single new file. Shared types used by all three new tests:
+
+```csharp
+[Policy("TestPolicy")]
+public sealed class TestPolicy : IAuthorizationPolicy { ... }
+
+[RequirePolicy("TestPolicy")]
+public sealed record TestRequest(int Value) : IRequest<TestResponse>;
+public sealed record TestResponse(int Echo);
+
+internal sealed class TestHandler : IRequestHandler<TestRequest, TestResponse>
+{
+    public Task<TestResponse> Handle(TestRequest req, CancellationToken ct)
+        => Task.FromResult(new TestResponse(req.Value));
+}
+
+internal sealed class FakeSecurityContextAccessor : ISecurityContextAccessor
+{
+    // AsyncLocal so future xUnit collection-level parallelism doesn't bleed
+    // claims across tests. Set per-test via SetClaims(...).
+    private static readonly AsyncLocal<IReadOnlyDictionary<string, string>?> _current = new();
+    public ISecurityContext GetCurrent() => new TestSecurityContext(_current.Value ?? EmptyDict);
+    public static void SetClaims(IReadOnlyDictionary<string, string> claims) => _current.Value = claims;
+}
+
+internal sealed class InvocationCounter { public int Count; }
+
+[PipelineBehavior(Order = -500)] // numerically AFTER Authorization (-1000)
+internal sealed class CountingDownstreamBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+{
+    private readonly InvocationCounter _counter;
+    public CountingDownstreamBehavior(InvocationCounter counter) => _counter = counter;
+    public Task<TResponse> Handle(TRequest req, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+    {
+        _counter.Count++;
+        return next();
+    }
+}
+```
+
+### Test 1 — pipeline ordering (#4)
+
+```csharp
+[Fact]
+public async Task Pipeline_ordering_authorization_runs_before_later_behaviors()
+{
+    var counter = new InvocationCounter();
+    var sp = BuildContainer(services =>
+    {
+        services.AddSingleton(counter);
+        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(CountingDownstreamBehavior<,>));
+    });
+
+    FakeSecurityContextAccessor.SetClaims(EmptyDict); // no claims → TestPolicy denies
+    var mediator = sp.GetRequiredService<IMediator>();
+    var result = await mediator.Send(new TestRequest(42));
+
+    Assert.Equal(0, counter.Count);  // proves ordering: downstream stub never ran
+    Assert.True(IsAuthDenial(result));
+}
+```
+
+The stub at `Order = -500` is numerically AFTER Authorization's `-1000`. If
+Authorization runs first AND short-circuits on deny, the stub never fires
+→ `counter.Count == 0`. If a future change inverts the ordering, the stub
+fires → assertion catches it.
+
+**Swap-test for the assertion's meaningfulness:** changing the stub's Order
+to `-2000` (numerically before Authorization) must make this test FAIL with
+`counter.Count == 1`. Verified manually pre-merge and documented as a
+comment above the test.
+
+### Test 2 — end-to-end allow path (#5)
+
+```csharp
+[Fact]
+public async Task End_to_end_through_IMediator_Send_allow_path()
+{
+    var sp = BuildContainer(_ => { });
+    FakeSecurityContextAccessor.SetClaims(new Dictionary<string, string> { ["sub"] = "test-user" });
+
+    var mediator = sp.GetRequiredService<IMediator>();
+    var result = await mediator.Send(new TestRequest(42));
+
+    Assert.True(IsAllowedResult(result));
+    Assert.Equal(42, ExtractValue(result));  // handler actually invoked
+}
+```
+
+### Test 3 — end-to-end deny path (#5)
+
+```csharp
+[Fact]
+public async Task End_to_end_through_IMediator_Send_deny_path()
+{
+    var sp = BuildContainer(_ => { });
+    FakeSecurityContextAccessor.SetClaims(EmptyDict);
+
+    var mediator = sp.GetRequiredService<IMediator>();
+    var result = await mediator.Send(new TestRequest(42));
+
+    Assert.True(IsAuthDenial(result));  // handler must NOT have run
+}
+```
+
+### Shared container builder
+
+```csharp
+private static ServiceProvider BuildContainer(Action<IServiceCollection> extra)
+{
+    var services = new ServiceCollection();
+    services.AddScoped<ISecurityContextAccessor, FakeSecurityContextAccessor>();
+    services.AddSingleton<IRequestHandler<TestRequest, TestResponse>, TestHandler>();
+    services.AddMediator().WithAuthorization(o => o.UseAccessor<FakeSecurityContextAccessor>());
+    extra(services);
+    return services.BuildServiceProvider();
+}
+```
+
+The exact `IsAllowedResult` / `IsAuthDenial` / `ExtractValue` helpers mirror
+the shape the existing `AuthorizationBehaviorTests` use (typed-failure
+`Result<TResponse, AuthorizationFailure>` vs thrown denial), determined at
+coding time so the new tests read consistently with the existing suite.
+
+### AOT smoke restructure (#6)
+
+`samples/ZeroAlloc.Mediator.AotSmoke/AuthorizedScenario.cs`:
+
+```csharp
+// Setup (outside any gate; setup cost is irrelevant to allocation budgets):
+private readonly AuthorizationBehavior<TestRequest, TestResponse> _behavior;
+private readonly TestRequest _allowRequest = new(1);
+private readonly TestRequest _denyRequest = new(2);
+private readonly TestResponse _okResponse = new(99);
+private readonly RequestHandlerDelegate<TestResponse> _next;
+
+ctor:
+    _behavior = new AuthorizationBehavior<TestRequest, TestResponse>(/* policy registry, accessor */);
+    _next = () => Task.FromResult(_okResponse);
+    // Pre-build allow / deny security contexts so the gate measures Handle only.
+
+// Inside the allocation gate (replaces today's policy.EvaluateAsync gate):
+gate.Measure("authorized-allow-handle", () =>
+    _behavior.Handle(_allowRequest, _next, ct: default).GetAwaiter().GetResult());
+gate.Measure("authorized-deny-handle", () =>
+    _behavior.Handle(_denyRequest, _next, ct: default).GetAwaiter().GetResult());
+```
+
+No DI container, no dispatcher, no `AuthorizationBehaviorState` access. Just
+the behavior, the `RequestHandlerDelegate next`, and the security context.
+
+**Allocation budgets:** start at the values used by the corresponding JIT
+unit tests (`Behavior_*Allow_ZeroAllocation` / `Behavior_*Deny_ZeroAllocation`,
+already passing). If the AOT runtime shows higher allocation than JIT, bump
+the AOT budget with an inline comment noting the AOT-vs-JIT delta.
+
+### `InternalsVisibleTo` removal (#7)
+
+After the smoke refactor, delete from
+`src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj`:
+
+```xml
+<InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />
+```
+
+Validation: `dotnet build samples/ZeroAlloc.Mediator.AotSmoke/...` must
+succeed cleanly. If it fails, the smoke still touches internals — STOP and
+either make the symbol public (if safe) OR refactor the smoke. Do not
+reintroduce the IVT silently.
+
+If `PublicAPI.Unshipped.txt` references the removed visibility, drop those
+lines.
+
+### Constructor accessibility risk
+
+If `AuthorizationBehavior<TRequest, TResponse>`'s constructor is `internal`
+(plausible since today the smoke constructs via internals), the refactor in
+Section 3 can't construct it directly without the IVT. In that case the fix
+splits:
+
+1. Promote the constructor to `public` (or add a `public static
+   CreateForTesting(...)` factory).
+2. Add the new symbol to `PublicAPI.Unshipped.txt`.
+3. Only then drop the IVT.
+
+This is a strictly additive PublicAPI change — no removals, no signature
+changes — so the SemVer impact is none.
+
+## Testing
+
+- `dotnet test tests/ZeroAlloc.Mediator.Authorization.Tests` shows 3 new
+  passing tests on top of the existing suite.
+- Manual swap-test on the ordering test verified the assertion catches the
+  inverted-Order regression.
+- `dotnet publish -p:PublishAot=true samples/ZeroAlloc.Mediator.AotSmoke`
+  succeeds AND the new `authorized-*-handle` gates pass their budgets at
+  runtime.
+- `dotnet build` of the smoke csproj succeeds after the IVT removal.
+
+## Out of scope
+
+- Streaming-request authorization (backlog calls this out as deferred).
+- OpenTelemetry on the deny path (deferred).
+- Item #10 (org-wide AllocationGate factor-out) — deferred by its own
+  graduation signal.
+- Real `ZeroAlloc.Mediator.Validation` integration test — explicitly
+  rejected during brainstorming (B over A on test approach): the stub
+  approach decouples this test from the Validation package's behavior.

--- a/docs/plans/2026-05-22-mediator-authorization-integration-tests.md
+++ b/docs/plans/2026-05-22-mediator-authorization-integration-tests.md
@@ -1,0 +1,730 @@
+# Mediator.Authorization Integration Tests Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Land backlog items #4 (pipeline-ordering integration test), #5 (end-to-end via `IMediator.Send`), #6 (AOT smoke certifies Mediator.Authorization wiring, not policy library), and #7 (drop `InternalsVisibleTo "ZeroAlloc.Mediator.AotSmoke"`).
+
+**Architecture:** Three additions to the test fixture in `TestFixtures.cs` (a local pipeline-behavior shim that lets the test assembly's Mediator generator wire `AuthorizationBehavior` into `IMediator.Send`; a counting downstream behavior to prove ordering; one new policy/request/handler triple). One new test file `IntegrationTests.cs` with three test methods. One additive PublicAPI change promoting `AuthorizationBehaviorAccessor` and `AuthorizationBehaviorState` to `public` so the AOT smoke can resolve the accessor instead of touching the static directly. Refactor of the AOT smoke to use the accessor + drop the redundant policy-only allocation gate. Removal of one `<InternalsVisibleTo>` entry.
+
+**Tech Stack:** .NET 10 / .NET 8 multi-targeted, xUnit 2.x, ZeroAlloc.Mediator's source-generator-driven pipeline (`[PipelineBehavior(Order = N)]` on `IPipelineBehavior`-implementing classes with `static Handle<TRequest, TResponse>`), ZeroAlloc.Authorization v2 source generator (`[Policy]` / `[RequirePolicy]`), Microsoft.CodeAnalysis.PublicApiAnalyzers (PublicAPI.Shipped.txt / Unshipped.txt convention).
+
+**Design doc:** `docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md`
+
+**Working branch:** `test/mediator-authorization-integration-tests` (already created off `main` at `cf7ecd4`).
+
+**Key context to keep in mind while implementing:**
+
+- ZA.Mediator pipeline behaviors are sealed classes implementing the non-generic marker `IPipelineBehavior`, decorated with `[PipelineBehavior(Order = N)]`, exposing a `public static ValueTask<TResponse> Handle<TRequest, TResponse>(TRequest request, CancellationToken ct, Func<TRequest, CancellationToken, ValueTask<TResponse>> next)` method. **Not** a generic interface.
+- The Mediator generator only sees behaviors in the **current compilation**. `AuthorizationBehavior` lives in the `ZeroAlloc.Mediator.Authorization` assembly and is **invisible** to the test assembly's generator. The shim added in Task 2 is what makes `IMediator.Send` exercise the real behavior — the generator picks up the shim, the shim forwards to `AuthorizationBehavior.Handle`.
+- `AuthorizationBehaviorState.ServiceProvider` is a `static volatile` field. `AuthorizationBehaviorAccessor`'s constructor sets it as a side-effect. The ctor runs when something resolves `AuthorizationBehaviorAccessor` from DI. `WithAuthorization()` registers the accessor as a singleton with a factory — lazy until first resolution.
+- Tests run under `[Collection("non-parallel-authorization")]` because the static service-provider field would stomp across parallel tests. New integration tests need the same collection.
+
+---
+
+## Task 1: Promote `AuthorizationBehaviorAccessor` + `AuthorizationBehaviorState` to public
+
+**Files:**
+- Modify: `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator/src/ZeroAlloc.Mediator.Authorization/AuthorizationBehaviorAccessor.cs`
+- Modify: `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator/src/ZeroAlloc.Mediator.Authorization/PublicAPI.Unshipped.txt`
+
+**Step 1: Promote both types**
+
+Open `AuthorizationBehaviorAccessor.cs`. Replace the existing contents with:
+
+```csharp
+using System;
+
+namespace ZeroAlloc.Mediator.Authorization;
+
+#pragma warning disable MA0048 // file groups behavior-public accessor + state
+/// <summary>
+/// Static carrier for the active <see cref="IServiceProvider"/> consumed by
+/// <see cref="AuthorizationBehavior.Handle{TRequest, TResponse}"/>. Set via
+/// <see cref="AuthorizationBehaviorAccessor"/>'s constructor on first DI
+/// resolution after <see cref="MediatorAuthorizationServiceCollectionExtensions.WithAuthorization"/>.
+/// </summary>
+/// <remarks>
+/// Public so non-Mediator hosts (samples, AOT smoke binaries) can resolve the
+/// accessor explicitly instead of writing the field directly — see
+/// <see cref="AuthorizationBehaviorAccessor"/>.
+/// </remarks>
+public static class AuthorizationBehaviorState
+{
+    /// <summary>The active provider for the authorization behavior, or <see langword="null"/> until first accessor construction.</summary>
+    public static volatile IServiceProvider? ServiceProvider;
+}
+
+/// <summary>
+/// DI-resolved hook whose constructor side-effects
+/// <see cref="AuthorizationBehaviorState.ServiceProvider"/>. Registered as a
+/// singleton by <see cref="MediatorAuthorizationServiceCollectionExtensions.WithAuthorization"/>;
+/// resolve it once after <c>BuildServiceProvider()</c> to initialise the
+/// behavior's view of the container.
+/// </summary>
+public sealed class AuthorizationBehaviorAccessor
+{
+    /// <summary>Stores the provided <paramref name="serviceProvider"/> into <see cref="AuthorizationBehaviorState.ServiceProvider"/>.</summary>
+    public AuthorizationBehaviorAccessor(IServiceProvider serviceProvider) =>
+        AuthorizationBehaviorState.ServiceProvider = serviceProvider;
+}
+#pragma warning restore MA0048
+```
+
+The only access-level changes are `internal` → `public` on the type declarations and the field/constructor. The runtime behaviour is identical.
+
+**Step 2: Update PublicAPI.Unshipped.txt**
+
+Open `PublicAPI.Unshipped.txt`. Add the following entries (alphabetical order matters for the PublicApiAnalyzer — insert in the right place):
+
+```
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorAccessor
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorAccessor.AuthorizationBehaviorAccessor(System.IServiceProvider! serviceProvider) -> void
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState
+static ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState.ServiceProvider -> System.IServiceProvider?
+```
+
+The `static ... .ServiceProvider -> System.IServiceProvider?` line covers a public `volatile` field. The PublicApiAnalyzer accepts the field-declaration syntax verbatim (no separate getter/setter entries for fields).
+
+If your editor or analyzer suggests slightly different lines (e.g. nullable-annotation symbol placement), accept its suggestion — Roslyn's analyzer is the source of truth for the exact text. The `RS0016` / `RS0017` rules will fail the build if the lines are wrong.
+
+**Step 3: Verify the build still passes**
+
+Run from the repo root:
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+dotnet build src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj -c Release
+```
+
+Expected: build SUCCEEDED with 0 warnings, 0 errors. If `RS0016` or `RS0017` fires, fix the `PublicAPI.Unshipped.txt` lines per the analyzer's diagnostic message.
+
+**Step 4: Commit**
+
+```bash
+git add src/ZeroAlloc.Mediator.Authorization/AuthorizationBehaviorAccessor.cs \
+        src/ZeroAlloc.Mediator.Authorization/PublicAPI.Unshipped.txt
+git commit -m "feat(authorization): promote AuthorizationBehaviorAccessor + State to public
+
+The smoke binary needs to resolve AuthorizationBehaviorAccessor from DI to
+trigger its static-init side effect, instead of writing
+AuthorizationBehaviorState.ServiceProvider directly via InternalsVisibleTo.
+Additive PublicAPI change: no signature changes, no removals.
+
+Prepares for InternalsVisibleTo \"ZeroAlloc.Mediator.AotSmoke\" removal
+(backlog #7)."
+```
+
+---
+
+## Task 2: Add integration-test fixture types
+
+**Files:**
+- Modify: `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator/tests/ZeroAlloc.Mediator.Authorization.Tests/TestFixtures.cs`
+
+**Step 1: Add the new fixture types**
+
+Open `TestFixtures.cs`. Add these entries; placement guidance below.
+
+Add a new policy alongside the existing policy declarations (e.g. after `CancellablePolicy`):
+
+```csharp
+[Policy("IntegrationTest")]
+public sealed class IntegrationTestPolicy : IAuthorizationPolicy
+{
+    // Allow when the security context carries the "Admin" role; deny otherwise.
+    public ValueTask<UnitResult<AuthorizationFailure>> EvaluateAsync(
+        ISecurityContext ctx, CancellationToken ct = default)
+        => new(ctx.Roles.Contains("Admin")
+            ? UnitResult<AuthorizationFailure>.Success()
+            : new AuthorizationFailure(AuthorizationFailure.DefaultDenyCode, "needs Admin"));
+}
+```
+
+Add a new request type next to the existing request records (after `GetThingUnauthorized`):
+
+```csharp
+// Integration tests drive this through IMediator.Send. The shim below
+// (AuthorizationBehaviorShim) is what the test-assembly's Mediator generator
+// picks up to wire AuthorizationBehavior.Handle into the dispatcher; this
+// request just exists to be sent.
+[RequirePolicy("IntegrationTest")]
+public sealed record IntegrationTestRequest(int Value) : IRequest<int>;
+```
+
+Add a handler in the stub-handler block (after `StubGetThingUnauthorizedHandler`):
+
+```csharp
+public sealed class IntegrationTestHandler : IRequestHandler<IntegrationTestRequest, int>
+{
+    public ValueTask<int> Handle(IntegrationTestRequest r, CancellationToken ct)
+        => ValueTask.FromResult(r.Value * 2);
+}
+```
+
+Add the counter holder, the shim, and the counting behavior at the bottom of the file (before the `[CollectionDefinition]` block):
+
+```csharp
+// Mutable counter resolved by CountingDownstreamBehavior to record whether
+// downstream pipeline behaviors ran on a given Send. AddSingleton in tests.
+internal sealed class InvocationCounter { public int Count; }
+
+// Local shim — the test-assembly's Mediator generator sees this in the
+// current compilation (cross-assembly AuthorizationBehavior is invisible to
+// it). The shim's static Handle just forwards to the real behavior. Same
+// Order constant (-1000), identical contract.
+[PipelineBehavior(Order = -1000)]
+public sealed class AuthorizationBehaviorShim : IPipelineBehavior
+{
+    public static ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request, CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+        => AuthorizationBehavior.Handle<TRequest, TResponse>(request, ct, next);
+}
+
+// Numerically AFTER the shim (-500 > -1000): runs only if the shim did NOT
+// short-circuit. The integration tests assert this counter to prove
+// pipeline ordering took effect.
+[PipelineBehavior(Order = -500)]
+public sealed class CountingDownstreamBehavior : IPipelineBehavior
+{
+    public static ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request, CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+    {
+        // Reads via AuthorizationBehaviorState (now public after Task 1).
+        // Tests can also read AuthorizationBehaviorState themselves — fine
+        // since the field is public now.
+        AuthorizationBehaviorState.ServiceProvider!
+            .GetRequiredService<InvocationCounter>().Count++;
+        return next(request, ct);
+    }
+}
+```
+
+Add an `using Microsoft.Extensions.DependencyInjection;` at the top of `TestFixtures.cs` if it's not already imported (the file already uses DI in test types, so verify).
+
+**Step 2: Verify the test assembly still compiles**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+dotnet build tests/ZeroAlloc.Mediator.Authorization.Tests/ZeroAlloc.Mediator.Authorization.Tests.csproj -c Release
+```
+
+Expected: SUCCEEDED, 0 errors. There may be `ZAM001` ("no handler registered") warnings if the source generator runs before DI registration — those are emitted during the build and should remain absent because `IntegrationTestHandler` is now declared in the same compilation. If they fire, double-check the handler class is `public sealed class IntegrationTestHandler : IRequestHandler<...>`.
+
+**Step 3: Run the existing test suite — must remain green**
+
+```bash
+dotnet test tests/ZeroAlloc.Mediator.Authorization.Tests/ZeroAlloc.Mediator.Authorization.Tests.csproj -c Release
+```
+
+Expected: every existing test passes. The new pipeline-behavior classes are wired into the test-assembly's `MediatorService` partial, but none of the existing tests use `IMediator.Send` — they all call `AuthorizationBehavior.Handle` directly — so the shim and counting behavior never execute in those paths.
+
+**Step 4: Commit**
+
+```bash
+git add tests/ZeroAlloc.Mediator.Authorization.Tests/TestFixtures.cs
+git commit -m "test(fixtures): add integration-test shim + counting behavior
+
+Adds AuthorizationBehaviorShim — a local [PipelineBehavior(Order=-1000)]
+class whose static Handle forwards to AuthorizationBehavior.Handle. This
+is the bridge that makes the test-assembly's Mediator generator wire the
+real behavior into IMediator.Send (the cross-assembly behavior is
+invisible to the generator).
+
+Adds CountingDownstreamBehavior at Order=-500 (numerically after the
+shim) for ordering assertions, plus an InvocationCounter holder, plus
+IntegrationTestPolicy / IntegrationTestRequest / IntegrationTestHandler
+used by the new integration tests in the next commit.
+
+No existing tests use IMediator.Send, so the new pipeline behaviors do
+not affect their behaviour — verified by the green test run."
+```
+
+---
+
+## Task 3: Add `IntegrationTests.cs`
+
+**Files:**
+- Create: `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator/tests/ZeroAlloc.Mediator.Authorization.Tests/IntegrationTests.cs`
+
+**Step 1: Write the test file**
+
+Create `IntegrationTests.cs` with this content verbatim:
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Authorization;
+using ZeroAlloc.Authorization.Generated;
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Mediator.Authorization;
+using Xunit;
+
+namespace ZeroAlloc.Mediator.Authorization.Tests;
+
+// Integration tests covering backlog items #4 (pipeline ordering) and #5
+// (end-to-end via IMediator.Send). These complement AuthorizationBehaviorTests,
+// which drives AuthorizationBehavior.Handle directly with a mocked next
+// delegate. The tests here exercise the full chain: DI container build →
+// AuthorizationBehaviorAccessor sets the static → Mediator generator's
+// dispatcher routes IMediator.Send through AuthorizationBehaviorShim →
+// shim forwards to AuthorizationBehavior.Handle → AuthorizerFor + policy +
+// CountingDownstreamBehavior + handler.
+//
+// All three tests use [Collection("non-parallel-authorization")] because
+// AuthorizationBehaviorState.ServiceProvider is a static field; running in
+// parallel would stomp it across tests.
+//
+// Swap-test for the ordering assertion's meaningfulness: temporarily change
+// CountingDownstreamBehavior's attribute in TestFixtures.cs to
+// [PipelineBehavior(Order = -2000)] (numerically BEFORE the shim's -1000).
+// The Pipeline_ordering_authorization_runs_before_later_behaviors test must
+// then FAIL with counter.Count == 1 — proving the test catches a real
+// regression in pipeline ordering. Revert after verifying. Recommended any
+// time the Mediator core's pipeline-ordering algorithm changes.
+[Collection("non-parallel-authorization")]
+public sealed class IntegrationTests
+{
+    [Fact]
+    public async Task Pipeline_ordering_authorization_runs_before_later_behaviors()
+    {
+        var counter = new InvocationCounter();
+        using var sp = BuildProvider(counter, TestSecurityContexts.With()); // no Admin → policy denies
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await Assert.ThrowsAsync<AuthorizationDeniedException>(async () =>
+            await mediator.Send(new IntegrationTestRequest(42)));
+
+        // Proves ordering: CountingDownstreamBehavior (Order=-500) never ran
+        // because AuthorizationBehaviorShim (Order=-1000) short-circuited
+        // ahead of it via AuthorizationDeniedException.
+        Assert.Equal(0, counter.Count);
+    }
+
+    [Fact]
+    public async Task End_to_end_through_IMediator_Send_allow_path()
+    {
+        var counter = new InvocationCounter();
+        using var sp = BuildProvider(counter, TestSecurityContexts.With("Admin"));
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new IntegrationTestRequest(7));
+
+        Assert.Equal(14, result);          // handler invoked: 7 * 2
+        Assert.Equal(1, counter.Count);    // downstream behavior ran on the allow path
+    }
+
+    [Fact]
+    public async Task End_to_end_through_IMediator_Send_deny_path()
+    {
+        var counter = new InvocationCounter();
+        using var sp = BuildProvider(counter, TestSecurityContexts.With()); // no Admin
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await Assert.ThrowsAsync<AuthorizationDeniedException>(async () =>
+            await mediator.Send(new IntegrationTestRequest(7)));
+
+        // Handler must NOT have run — the shim short-circuited via the throw.
+        Assert.Equal(0, counter.Count);
+    }
+
+    private static ServiceProvider BuildProvider(InvocationCounter counter, ISecurityContext ctx)
+    {
+        var services = new ServiceCollection();
+        services.AddZeroAllocAuthorization();
+        services.AddSingleton(counter);
+        services.AddScoped<ISecurityContextAccessor>(_ => new TestSecurityContextAccessor { Current = ctx });
+        services.AddMediator().WithAuthorization(o => o.UseAccessor<ISecurityContextAccessor>());
+        var sp = services.BuildServiceProvider();
+
+        // Trigger AuthorizationBehaviorAccessor's ctor → sets the static
+        // ServiceProvider so the shim can resolve AuthorizerFor + the
+        // security context per request. Equivalent to what
+        // AuthorizationBehaviorState.ServiceProvider = sp would do via
+        // internals, but goes through the public accessor.
+        _ = sp.GetRequiredService<AuthorizationBehaviorAccessor>();
+        return sp;
+    }
+}
+```
+
+**Step 2: Run the new tests**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+dotnet test tests/ZeroAlloc.Mediator.Authorization.Tests/ -c Release --filter "FullyQualifiedName~IntegrationTests"
+```
+
+Expected: 3 tests pass.
+
+If `Pipeline_ordering_authorization_runs_before_later_behaviors` fails with `counter.Count == 1`, the pipeline-ordering invariant has actually regressed in ZeroAlloc.Mediator — STOP and investigate, do not patch the test.
+
+If the allow-path test fails (`result` is not 14, or `counter.Count` is not 1), check that `IntegrationTestHandler` is registered (the generator should auto-discover it as the request's handler in the test-assembly compilation).
+
+If the deny-path test throws something other than `AuthorizationDeniedException`, check that the shim correctly forwards (no try-catch around the inner call).
+
+**Step 3: Run the full test suite once more**
+
+```bash
+dotnet test tests/ZeroAlloc.Mediator.Authorization.Tests/ -c Release
+```
+
+Expected: every test in the project passes, including the 3 new ones.
+
+**Step 4: Commit**
+
+```bash
+git add tests/ZeroAlloc.Mediator.Authorization.Tests/IntegrationTests.cs
+git commit -m "test(integration): cover pipeline ordering + IMediator.Send end-to-end
+
+Three tests using the shim fixtures from the previous commit:
+
+  - Pipeline_ordering_authorization_runs_before_later_behaviors (backlog #4):
+    proves Order=-1000 short-circuits before Order=-500 fires.
+  - End_to_end_through_IMediator_Send_allow_path (backlog #5):
+    allow path returns handler's result through real dispatcher.
+  - End_to_end_through_IMediator_Send_deny_path (backlog #5):
+    deny path surfaces AuthorizationDeniedException without invoking
+    the handler.
+
+Comment documents the swap-test for verifying the ordering assertion is
+meaningful: flip the counting behavior's Order to -2000 (before the shim)
+and the test must fail with counter.Count == 1."
+```
+
+---
+
+## Task 4: Refactor the AOT smoke to drop direct `AuthorizationBehaviorState` access
+
+**Files:**
+- Modify: `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator/samples/ZeroAlloc.Mediator.AotSmoke/Authorization/AuthorizedScenario.cs`
+
+**Step 1: Replace the six `AuthorizationBehaviorState.ServiceProvider = ...` lines**
+
+Find each occurrence (six in total — lines 108, 119, 137, 150, 168 plus the gate setup). The current pattern is:
+
+```csharp
+AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider;
+```
+
+Replace each occurrence with:
+
+```csharp
+// Resolving AuthorizationBehaviorAccessor triggers its ctor, which sets
+// AuthorizationBehaviorState.ServiceProvider as a side effect.
+_ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
+```
+
+The behaviour is identical to direct field assignment because the accessor's
+constructor does the same write. Importantly, no more `internal` access to
+`AuthorizationBehaviorState` is required — both types are public after Task 1.
+
+`AuthorizationBehaviorAccessor` was registered as a singleton by
+`WithAuthorization()`, so the first resolution caches it; subsequent
+`BuildProvider` calls return fresh providers and a fresh accessor each time
+(the singleton is per-IServiceProvider, not per-process).
+
+**Step 2: Drop the policy-only allocation gate (backlog #6)**
+
+Locate `VerifyAllocationBudget` in `AuthorizedScenario.cs`. The method
+currently ends with two `AllocationGate.AssertBudgetValueTask` calls. The
+first measures `AuthorizationBehavior.Handle` (KEEP). The second measures
+`policy.EvaluateAsync` (DELETE — this certifies ZeroAlloc.Authorization,
+already certified upstream).
+
+Delete the block:
+
+```csharp
+// Direct policy invocation — tightest budget (0 B/call) on v2's single-method
+// IAuthorizationPolicy.EvaluateAsync returning UnitResult<AuthorizationFailure>.
+IAuthorizationPolicy policy = new AotAdminPolicy();
+AllocationGate.AssertBudgetValueTask(0, 1000,
+    () => policy.EvaluateAsync(adminCtx),
+    "Policy.EvaluateAsync (AOT smoke allow)");
+```
+
+Keep the preceding `AuthorizationBehavior.Handle` gate.
+
+**Step 3: Verify the smoke still compiles**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+dotnet build samples/ZeroAlloc.Mediator.AotSmoke/ZeroAlloc.Mediator.AotSmoke.csproj -c Release
+```
+
+Expected: SUCCEEDED, 0 errors. The smoke is still using the IVT to ZeroAlloc.Mediator.Authorization here (Task 5 removes it), so any other internal access (if any) still works at this point.
+
+**Step 4: Run the smoke under .NET (JIT) before AOT publish**
+
+```bash
+dotnet run --project samples/ZeroAlloc.Mediator.AotSmoke/ZeroAlloc.Mediator.AotSmoke.csproj -c Release
+```
+
+Expected: every scenario completes, including `[Authorization AotSmoke] OK`. The output should NOT include the dropped `Policy.EvaluateAsync (AOT smoke allow)` gate line; the remaining `AuthorizationBehavior.Handle (AOT smoke allow happy path)` line should print as before.
+
+**Step 5: AOT publish and run**
+
+```bash
+dotnet publish samples/ZeroAlloc.Mediator.AotSmoke/ZeroAlloc.Mediator.AotSmoke.csproj -c Release -p:PublishAot=true -o ./aot-out/AotSmoke
+./aot-out/AotSmoke/ZeroAlloc.Mediator.AotSmoke
+```
+
+Expected: same console output as the JIT run; AOT compilation succeeded; allocation budgets pass.
+
+If the Handle gate now allocates over budget, this is a new failure mode introduced by the refactor — STOP and inspect: confirm the `GetRequiredService<AuthorizationBehaviorAccessor>()` call is in setup, NOT inside the gated lambda (the gated lambda should still be the bare `AuthorizationBehavior.Handle<...>(...)` call).
+
+**Step 6: Commit**
+
+```bash
+git add samples/ZeroAlloc.Mediator.AotSmoke/Authorization/AuthorizedScenario.cs
+git commit -m "fix(aotsmoke): use AuthorizationBehaviorAccessor; drop policy-only gate
+
+Two changes (backlog #6 + prep for #7):
+
+  - Replace all six AuthorizationBehaviorState.ServiceProvider = ... lines
+    with AuthorizationBehaviorAccessor resolution. Same side effect; goes
+    through the public surface (Task 1) instead of InternalsVisibleTo.
+  - Drop the policy.EvaluateAsync allocation gate from VerifyAllocationBudget.
+    That gate certifies ZeroAlloc.Authorization (already certified in that
+    repo's own smoke), not Mediator.Authorization. The remaining
+    AuthorizationBehavior.Handle gate is the one that does this smoke's job.
+
+AOT publish + run still passes — JIT and AOT both certify Handle's allocation
+budget against the same 512 B / 1000-iter envelope."
+```
+
+---
+
+## Task 5: Remove `InternalsVisibleTo "ZeroAlloc.Mediator.AotSmoke"`
+
+**Files:**
+- Modify: `c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator/src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj`
+
+**Step 1: Delete the IVT line**
+
+Open the csproj and find the `<ItemGroup>` containing the two `<InternalsVisibleTo>` entries. Delete the AotSmoke entry only:
+
+Before:
+
+```xml
+<ItemGroup>
+  <InternalsVisibleTo Include="ZeroAlloc.Mediator.Authorization.Tests" />
+  <InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />
+</ItemGroup>
+```
+
+After:
+
+```xml
+<ItemGroup>
+  <InternalsVisibleTo Include="ZeroAlloc.Mediator.Authorization.Tests" />
+</ItemGroup>
+```
+
+The Tests entry stays — `CountingDownstreamBehavior` in `TestFixtures.cs` reads `AuthorizationBehaviorState.ServiceProvider` (now public, so this could be relaxed) and `AuthorizationBehaviorTests`/`AllocationBudgetTests` still set the static for direct-call cases (still public, ditto). Both could in principle be flipped over to the accessor pattern in a follow-up, but doing it now bloats this PR. Tests keep the IVT for the moment.
+
+**Step 2: Rebuild the smoke**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+dotnet build samples/ZeroAlloc.Mediator.AotSmoke/ZeroAlloc.Mediator.AotSmoke.csproj -c Release
+```
+
+Expected: SUCCEEDED, 0 errors. If the build fails with CS0122 (inaccessible due to its protection level) on `AuthorizationBehaviorState` or `AuthorizationBehaviorAccessor`, those types are still `internal` in source — confirm Task 1 was committed and pushed correctly.
+
+If any OTHER internal-only type from ZeroAlloc.Mediator.Authorization is referenced from the smoke that we haven't anticipated, the build will fail with CS0122 on that symbol. STOP and either (a) refactor the smoke to use a public alternative, or (b) promote the symbol to public via a follow-up PublicAPI change. Do NOT re-add the IVT silently.
+
+**Step 3: Run the smoke (JIT)**
+
+```bash
+dotnet run --project samples/ZeroAlloc.Mediator.AotSmoke/ZeroAlloc.Mediator.AotSmoke.csproj -c Release
+```
+
+Expected: same successful output as Task 4 Step 4.
+
+**Step 4: AOT publish + run**
+
+```bash
+dotnet publish samples/ZeroAlloc.Mediator.AotSmoke/ZeroAlloc.Mediator.AotSmoke.csproj -c Release -p:PublishAot=true -o ./aot-out/AotSmoke
+./aot-out/AotSmoke/ZeroAlloc.Mediator.AotSmoke
+```
+
+Expected: same successful output. AOT publish must still succeed without warnings about trimmed-out symbols.
+
+**Step 5: Commit**
+
+```bash
+git add src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj
+git commit -m "chore(authorization): drop InternalsVisibleTo \"ZeroAlloc.Mediator.AotSmoke\"
+
+The smoke now uses AuthorizationBehaviorAccessor (resolved from DI) to
+trigger the static-init side effect, instead of writing
+AuthorizationBehaviorState.ServiceProvider via internals. Completes
+backlog #7.
+
+The InternalsVisibleTo to ZeroAlloc.Mediator.Authorization.Tests stays;
+the test suite still has paths that touch internals (now-public types
+are still accessed via the IVT-imported namespace, harmless), and
+refactoring those is a separate cleanup."
+```
+
+---
+
+## Task 6: Verify swap-test for the ordering assertion (manual; do NOT commit)
+
+This validates that the `Pipeline_ordering_authorization_runs_before_later_behaviors` test catches an actual regression, not just any failure mode.
+
+**Step 1: Temporarily change `CountingDownstreamBehavior`'s Order**
+
+Open `tests/ZeroAlloc.Mediator.Authorization.Tests/TestFixtures.cs`. Find:
+
+```csharp
+[PipelineBehavior(Order = -500)]
+public sealed class CountingDownstreamBehavior : IPipelineBehavior
+```
+
+Change to:
+
+```csharp
+[PipelineBehavior(Order = -2000)]
+public sealed class CountingDownstreamBehavior : IPipelineBehavior
+```
+
+`-2000` is numerically BEFORE the shim's `-1000`, so the counter behavior should now fire ahead of authorization.
+
+**Step 2: Run the ordering test**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+dotnet test tests/ZeroAlloc.Mediator.Authorization.Tests/ -c Release \
+  --filter "FullyQualifiedName~IntegrationTests.Pipeline_ordering_authorization_runs_before_later_behaviors"
+```
+
+Expected: the test FAILS with `Assert.Equal(0, 1) - Actual: 1, Expected: 0`. This confirms the test's assertion meaningfully covers ordering — if a future refactor inverted the pipeline ordering, this test would catch it.
+
+If the test PASSES with `-2000` (counter still 0), the assertion isn't actually testing ordering; investigate before reverting.
+
+**Step 3: Revert**
+
+Change `Order = -2000` back to `Order = -500`. Confirm:
+
+```bash
+git diff tests/ZeroAlloc.Mediator.Authorization.Tests/TestFixtures.cs
+```
+
+should show no remaining changes.
+
+**Step 4: Run the full test suite to confirm reverted state**
+
+```bash
+dotnet test tests/ZeroAlloc.Mediator.Authorization.Tests/ -c Release
+```
+
+Expected: all tests pass.
+
+**No commit for this task** — the swap-test is a one-time verification. The procedure is documented in the comment block at the top of `IntegrationTests` so a future maintainer can repeat it.
+
+---
+
+## Task 7: Push the branch and open the PR
+
+**Step 1: Sanity check the commit history**
+
+```bash
+cd c:/Projects/Prive/ZeroAlloc/ZeroAlloc.Mediator
+git log --oneline origin/main..HEAD
+```
+
+Expected: design doc commit (`cf7ecd4`) + 5 implementation commits in this order:
+
+1. `feat(authorization): promote AuthorizationBehaviorAccessor + State to public`
+2. `test(fixtures): add integration-test shim + counting behavior`
+3. `test(integration): cover pipeline ordering + IMediator.Send end-to-end`
+4. `fix(aotsmoke): use AuthorizationBehaviorAccessor; drop policy-only gate`
+5. `chore(authorization): drop InternalsVisibleTo "ZeroAlloc.Mediator.AotSmoke"`
+
+If any commit is missing or out of order, do `git rebase -i origin/main` BEFORE pushing.
+
+**Step 2: Push the branch**
+
+```bash
+git push -u origin test/mediator-authorization-integration-tests
+```
+
+**Step 3: Open the PR**
+
+```bash
+gh pr create --title "test: Mediator.Authorization integration tests + AOT smoke restructure (backlog #4-#7)" --body "$(cat <<'EOF'
+## Summary
+
+Ships backlog items #4-#7 in one focused PR:
+
+- **#4** — new `Pipeline_ordering_authorization_runs_before_later_behaviors` integration test that proves `AuthorizationBehavior`'s `Order=-1000` short-circuits before later behaviors fire. Swap-test verified (changing the downstream stub's Order to `-2000` makes this test fail with `counter.Count == 1`).
+- **#5** — new `End_to_end_through_IMediator_Send_{allow,deny}_path` integration tests that exercise the real dispatcher → shim → real `AuthorizationBehavior` → `AuthorizerFor` → policy → handler chain.
+- **#6** — AOT smoke drops the redundant `policy.EvaluateAsync` allocation gate (that certifies ZeroAlloc.Authorization, not Mediator.Authorization). The `AuthorizationBehavior.Handle` gate that does Mediator.Authorization's job stays.
+- **#7** — `<InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />` removed from the Authorization csproj. The smoke now resolves the (newly-public) `AuthorizationBehaviorAccessor` from DI to trigger its static-init side effect.
+
+The integration tests required a small additive PublicAPI change: `AuthorizationBehaviorAccessor` and `AuthorizationBehaviorState` promoted from `internal` to `public`. No signature changes, no removals.
+
+## Why cross-assembly testing needed a shim
+
+The Mediator source generator discovers `[PipelineBehavior]`-decorated behaviors only in the current compilation. `AuthorizationBehavior` lives in `ZeroAlloc.Mediator.Authorization` (a referenced assembly) and is invisible to the test assembly's generator. The new `AuthorizationBehaviorShim` (local to the test assembly) is a thin pass-through that the generator picks up; the shim forwards to `AuthorizationBehavior.Handle`. This is the only viable way to drive the real behavior through `IMediator.Send` from the test assembly.
+
+## Design + plan
+
+- Design: `docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md`
+- Plan: `docs/plans/2026-05-22-mediator-authorization-integration-tests.md`
+
+## Test plan
+
+- [ ] CI green: build + tests + aot-smoke
+- [ ] AOT publish of the smoke still produces a working binary; allocation gates pass within budget
+- [ ] Existing test suite still 100% green (the new pipeline behaviors only execute on `IMediator.Send`; no other test goes through the dispatcher)
+- [ ] Swap-test for the ordering assertion verified manually pre-merge (documented inline)
+
+## Followup
+
+The test-assembly IVT to ZeroAlloc.Mediator.Authorization could be removed too, since the now-public `AuthorizationBehaviorState` covers the test fixture's needs. Left in for now to keep this PR focused on the smoke leak (#7); separate cleanup PR if/when needed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 4: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: build + aot-smoke + (any other) checks all pass.
+
+If CI fails, diagnose via `gh run view <run-id> --log-failed`. Likely failure modes:
+
+- `RS0016` / `RS0017` on PublicAPI.Unshipped.txt: fix the line text in Task 1's file per the analyzer's suggestion, amend Task 1's commit.
+- AOT publish trim warning on a newly-public type: investigate; the promoted symbols should be trim-safe (they only touch `IServiceProvider`, no reflection).
+- Pipeline-ordering test failing: indicates a real regression in ZeroAlloc.Mediator's pipeline ordering — file a separate issue, do not patch this test.
+
+---
+
+## Verification checklist (before merge)
+
+- [ ] Task 1: `AuthorizationBehaviorAccessor` + `AuthorizationBehaviorState` public; PublicAPI.Unshipped.txt has both entries; build clean.
+- [ ] Task 2: TestFixtures.cs has shim + counting behavior + integration types; existing tests still green.
+- [ ] Task 3: 3 new integration tests in IntegrationTests.cs, all passing.
+- [ ] Task 4: Smoke uses accessor; policy-only gate dropped; JIT + AOT runs succeed.
+- [ ] Task 5: IVT to AotSmoke removed; smoke build + JIT + AOT still pass.
+- [ ] Task 6: Swap-test verified (test fails with inverted Order, passes again after revert). No commit.
+- [ ] Task 7: PR opened with green CI.
+
+## Out of scope (documented in the design doc)
+
+- Streaming-request authorization.
+- OpenTelemetry on the deny path.
+- Item #10 (org-wide AllocationGate factor-out) — deferred per its own graduation signal.
+- Real `ZeroAlloc.Mediator.Validation` integration test — explicitly skipped during brainstorming.
+- Removing the `InternalsVisibleTo "ZeroAlloc.Mediator.Authorization.Tests"` entry — separate followup.

--- a/samples/ZeroAlloc.Mediator.AotSmoke/Authorization/AuthorizedScenario.cs
+++ b/samples/ZeroAlloc.Mediator.AotSmoke/Authorization/AuthorizedScenario.cs
@@ -105,7 +105,9 @@ internal static class AuthorizedScenario
         using (var sp = BuildProvider(adminCtx))
         using (var scope = sp.CreateScope())
         {
-            AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider;
+            // Resolving AuthorizationBehaviorAccessor triggers its ctor, which sets
+            // AuthorizationBehaviorState.ServiceProvider as a side effect.
+            _ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
             var allowResult = AuthorizationBehavior.Handle<AotThrowAllow, int>(
                 new AotThrowAllow(7), CancellationToken.None,
                 static (r, _) => ValueTask.FromResult(r.Id * 2)).GetAwaiter().GetResult();
@@ -116,7 +118,9 @@ internal static class AuthorizedScenario
         using (var sp = BuildProvider(anonCtx))
         using (var scope = sp.CreateScope())
         {
-            AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider;
+            // Resolving AuthorizationBehaviorAccessor triggers its ctor, which sets
+            // AuthorizationBehaviorState.ServiceProvider as a side effect.
+            _ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
             try
             {
                 _ = AuthorizationBehavior.Handle<AotThrowDeny, int>(
@@ -134,7 +138,9 @@ internal static class AuthorizedScenario
         using (var sp = BuildProvider(adminCtx))
         using (var scope = sp.CreateScope())
         {
-            AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider;
+            // Resolving AuthorizationBehaviorAccessor triggers its ctor, which sets
+            // AuthorizationBehaviorState.ServiceProvider as a side effect.
+            _ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
             var resultAllow = AuthorizationBehavior.Handle<AotResultAllow, Result<int, AuthorizationFailure>>(
                 new AotResultAllow(5), CancellationToken.None,
                 static (r, _) => ValueTask.FromResult<Result<int, AuthorizationFailure>>(r.Id * 2))
@@ -147,7 +153,9 @@ internal static class AuthorizedScenario
         using (var sp = BuildProvider(anonCtx))
         using (var scope = sp.CreateScope())
         {
-            AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider;
+            // Resolving AuthorizationBehaviorAccessor triggers its ctor, which sets
+            // AuthorizationBehaviorState.ServiceProvider as a side effect.
+            _ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
             var resultDeny = AuthorizationBehavior.Handle<AotResultDeny, Result<int, AuthorizationFailure>>(
                 new AotResultDeny(5), CancellationToken.None,
                 static (r, _) => ValueTask.FromResult<Result<int, AuthorizationFailure>>(r.Id))
@@ -165,20 +173,15 @@ internal static class AuthorizedScenario
         // absorbs the Debug-mode async state machine box; Release/AOT path is 0 B/call.
         using var sp = BuildProvider(adminCtx);
         using var scope = sp.CreateScope();
-        AuthorizationBehaviorState.ServiceProvider = scope.ServiceProvider;
+        // Resolving AuthorizationBehaviorAccessor triggers its ctor, which sets
+        // AuthorizationBehaviorState.ServiceProvider as a side effect.
+        _ = scope.ServiceProvider.GetRequiredService<AuthorizationBehaviorAccessor>();
         var req = new AotThrowAllow(7);
 
         AllocationGate.AssertBudgetValueTask(512, 1000,
             () => AuthorizationBehavior.Handle<AotThrowAllow, int>(req, CancellationToken.None,
                 static (r, _) => ValueTask.FromResult(r.Id * 2)),
             "AuthorizationBehavior.Handle (AOT smoke allow happy path)");
-
-        // Direct policy invocation — tightest budget (0 B/call) on v2's single-method
-        // IAuthorizationPolicy.EvaluateAsync returning UnitResult<AuthorizationFailure>.
-        IAuthorizationPolicy policy = new AotAdminPolicy();
-        AllocationGate.AssertBudgetValueTask(0, 1000,
-            () => policy.EvaluateAsync(adminCtx),
-            "Policy.EvaluateAsync (AOT smoke allow)");
     }
 
     private static ServiceProvider BuildProvider(AotCtx ctx)

--- a/src/ZeroAlloc.Mediator.Authorization/AuthorizationBehaviorAccessor.cs
+++ b/src/ZeroAlloc.Mediator.Authorization/AuthorizationBehaviorAccessor.cs
@@ -2,15 +2,37 @@ using System;
 
 namespace ZeroAlloc.Mediator.Authorization;
 
-#pragma warning disable MA0048 // file groups behavior-internal accessor + state
-internal static class AuthorizationBehaviorState
+#pragma warning disable MA0048 // file groups behavior-public accessor + state
+/// <summary>
+/// Static carrier for the active <see cref="IServiceProvider"/> consumed by
+/// <see cref="AuthorizationBehavior.Handle{TRequest, TResponse}"/>. Set via
+/// <see cref="AuthorizationBehaviorAccessor"/>'s constructor on first DI
+/// resolution after <see cref="MediatorAuthorizationServiceCollectionExtensions.WithAuthorization"/>.
+/// </summary>
+/// <remarks>
+/// Public so non-Mediator hosts (samples, AOT smoke binaries) can resolve the
+/// accessor explicitly instead of writing the field directly — see
+/// <see cref="AuthorizationBehaviorAccessor"/>.
+/// </remarks>
+public static class AuthorizationBehaviorState
 {
-    internal static volatile IServiceProvider? ServiceProvider;
+    /// <summary>The active provider for the authorization behavior, or <see langword="null"/> until first accessor construction.</summary>
+#pragma warning disable MA0069 // public mutable static is by-design: set by AuthorizationBehaviorAccessor ctor side-effect
+    public static volatile IServiceProvider? ServiceProvider;
+#pragma warning restore MA0069
 }
 
-internal sealed class AuthorizationBehaviorAccessor
+/// <summary>
+/// DI-resolved hook whose constructor side-effects
+/// <see cref="AuthorizationBehaviorState.ServiceProvider"/>. Registered as a
+/// singleton by <see cref="MediatorAuthorizationServiceCollectionExtensions.WithAuthorization"/>;
+/// resolve it once after <c>BuildServiceProvider()</c> to initialise the
+/// behavior's view of the container.
+/// </summary>
+public sealed class AuthorizationBehaviorAccessor
 {
-    internal AuthorizationBehaviorAccessor(IServiceProvider serviceProvider) =>
+    /// <summary>Stores the provided <paramref name="serviceProvider"/> into <see cref="AuthorizationBehaviorState.ServiceProvider"/>.</summary>
+    public AuthorizationBehaviorAccessor(IServiceProvider serviceProvider) =>
         AuthorizationBehaviorState.ServiceProvider = serviceProvider;
 }
 #pragma warning restore MA0048

--- a/src/ZeroAlloc.Mediator.Authorization/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Mediator.Authorization/PublicAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 ZeroAlloc.Mediator.Authorization.AuthorizationBehavior
 ZeroAlloc.Mediator.Authorization.AuthorizationBehavior.AuthorizationBehavior() -> void
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorAccessor
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorAccessor.AuthorizationBehaviorAccessor(System.IServiceProvider! serviceProvider) -> void
+ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState
 ZeroAlloc.Mediator.Authorization.AuthorizationDeniedException
 ZeroAlloc.Mediator.Authorization.AuthorizationDeniedException.AuthorizationDeniedException(ZeroAlloc.Authorization.AuthorizationFailure failure) -> void
 ZeroAlloc.Mediator.Authorization.AuthorizationDeniedException.Failure.get -> ZeroAlloc.Authorization.AuthorizationFailure
@@ -13,4 +16,5 @@ ZeroAlloc.Mediator.Authorization.ISecurityContextAccessor
 ZeroAlloc.Mediator.Authorization.ISecurityContextAccessor.Current.get -> ZeroAlloc.Authorization.ISecurityContext!
 ZeroAlloc.Mediator.Authorization.MediatorAuthorizationServiceCollectionExtensions
 static ZeroAlloc.Mediator.Authorization.AuthorizationBehavior.Handle<TRequest, TResponse>(TRequest request, System.Threading.CancellationToken ct, System.Func<TRequest, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResponse>>! next) -> System.Threading.Tasks.ValueTask<TResponse>
+static volatile ZeroAlloc.Mediator.Authorization.AuthorizationBehaviorState.ServiceProvider -> System.IServiceProvider?
 static ZeroAlloc.Mediator.Authorization.MediatorAuthorizationServiceCollectionExtensions.WithAuthorization(this ZeroAlloc.Mediator.IMediatorBuilder! builder, System.Action<ZeroAlloc.Mediator.Authorization.AuthorizationOptions!>? configure = null) -> ZeroAlloc.Mediator.IMediatorBuilder!

--- a/src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj
+++ b/src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ZeroAlloc.Mediator.Authorization.Tests" />
-    <InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />

--- a/tests/ZeroAlloc.Mediator.Authorization.Tests/IntegrationTests.cs
+++ b/tests/ZeroAlloc.Mediator.Authorization.Tests/IntegrationTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Authorization;
+using ZeroAlloc.Authorization.Generated;
+using ZeroAlloc.Mediator;
+using ZeroAlloc.Mediator.Authorization;
+using Xunit;
+
+namespace ZeroAlloc.Mediator.Authorization.Tests;
+
+// Integration tests covering backlog items #4 (pipeline ordering) and #5
+// (end-to-end via IMediator.Send). These complement AuthorizationBehaviorTests,
+// which drives AuthorizationBehavior.Handle directly with a mocked next
+// delegate. The tests here exercise the full chain: DI container build →
+// AuthorizationBehaviorAccessor sets the static → Mediator generator's
+// dispatcher routes IMediator.Send through AuthorizationBehaviorShim →
+// shim forwards to AuthorizationBehavior.Handle → AuthorizerFor + policy +
+// CountingDownstreamBehavior + handler.
+//
+// All three tests use [Collection("non-parallel-authorization")] because
+// AuthorizationBehaviorState.ServiceProvider is a static field; running in
+// parallel would stomp it across tests.
+//
+// Swap-test for the ordering assertion's meaningfulness: temporarily change
+// CountingDownstreamBehavior's attribute in TestFixtures.cs to
+// [PipelineBehavior(Order = -2000)] (numerically BEFORE the shim's -1000).
+// The Pipeline_ordering_authorization_runs_before_later_behaviors test must
+// then FAIL with counter.Count == 1 — proving the test catches a real
+// regression in pipeline ordering. Revert after verifying. Recommended any
+// time the Mediator core's pipeline-ordering algorithm changes.
+[Collection("non-parallel-authorization")]
+public sealed class IntegrationTests
+{
+    [Fact]
+    public async Task Pipeline_ordering_authorization_runs_before_later_behaviors()
+    {
+        var counter = new InvocationCounter();
+        using var sp = BuildProvider(counter, TestSecurityContexts.With()); // no Admin → policy denies
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await Assert.ThrowsAsync<AuthorizationDeniedException>(async () =>
+            await mediator.Send(new IntegrationTestRequest(42)));
+
+        // Proves ordering: CountingDownstreamBehavior (Order=-500) never ran
+        // because AuthorizationBehaviorShim (Order=-1000) short-circuited
+        // ahead of it via AuthorizationDeniedException.
+        Assert.Equal(0, counter.Count);
+    }
+
+    [Fact]
+    public async Task End_to_end_through_IMediator_Send_allow_path()
+    {
+        var counter = new InvocationCounter();
+        using var sp = BuildProvider(counter, TestSecurityContexts.With("Admin"));
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new IntegrationTestRequest(7));
+
+        Assert.Equal(14, result);          // handler invoked: 7 * 2
+        Assert.Equal(1, counter.Count);    // downstream behavior ran on the allow path
+    }
+
+    [Fact]
+    public async Task End_to_end_through_IMediator_Send_deny_path()
+    {
+        var counter = new InvocationCounter();
+        using var sp = BuildProvider(counter, TestSecurityContexts.With()); // no Admin
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await Assert.ThrowsAsync<AuthorizationDeniedException>(async () =>
+            await mediator.Send(new IntegrationTestRequest(7)));
+
+        // Handler must NOT have run — the shim short-circuited via the throw.
+        Assert.Equal(0, counter.Count);
+    }
+
+    private static ServiceProvider BuildProvider(InvocationCounter counter, ISecurityContext ctx)
+    {
+        var services = new ServiceCollection();
+        services.AddZeroAllocAuthorization();
+        services.AddSingleton(counter);
+        services.AddScoped<ISecurityContextAccessor>(_ => new TestSecurityContextAccessor { Current = ctx });
+        services.AddTransient<IntegrationTestHandler>();
+        services.AddMediator().WithAuthorization(o => o.UseAccessor<ISecurityContextAccessor>());
+        var sp = services.BuildServiceProvider();
+
+        // Trigger AuthorizationBehaviorAccessor's ctor → sets the static
+        // ServiceProvider so the shim can resolve AuthorizerFor + the
+        // security context per request. Equivalent to what
+        // AuthorizationBehaviorState.ServiceProvider = sp would do via
+        // internals, but goes through the public accessor.
+        _ = sp.GetRequiredService<AuthorizationBehaviorAccessor>();
+        return sp;
+    }
+}

--- a/tests/ZeroAlloc.Mediator.Authorization.Tests/TestFixtures.cs
+++ b/tests/ZeroAlloc.Mediator.Authorization.Tests/TestFixtures.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using ZeroAlloc.Authorization;
 using ZeroAlloc.Mediator;
 using ZeroAlloc.Results;
@@ -62,6 +63,17 @@ public sealed class CancellablePolicy : IAuthorizationPolicy
     }
 }
 
+[Policy("IntegrationTest")]
+public sealed class IntegrationTestPolicy : IAuthorizationPolicy
+{
+    // Allow when the security context carries the "Admin" role; deny otherwise.
+    public ValueTask<UnitResult<AuthorizationFailure>> EvaluateAsync(
+        ISecurityContext ctx, CancellationToken ct = default)
+        => new(ctx.Roles.Contains("Admin")
+            ? UnitResult<AuthorizationFailure>.Success()
+            : new AuthorizationFailure(AuthorizationFailure.DefaultDenyCode, "needs Admin"));
+}
+
 // Plain IRequest + [RequirePolicy] → throw path.
 [RequirePolicy("AlwaysAllow")]
 public sealed record GetThingThrowAllow(int Id) : IRequest<int>;
@@ -87,6 +99,13 @@ public sealed record GetThingCancellable(int Id) : IRequest<int>;
 // No [RequirePolicy] — for fail-open coverage.
 public sealed record GetThingUnauthorized(int Id) : IRequest<int>;
 
+// Integration tests drive this through IMediator.Send. The shim below
+// (AuthorizationBehaviorShim) is what the test-assembly's Mediator generator
+// picks up to wire AuthorizationBehavior.Handle into the dispatcher; this
+// request just exists to be sent.
+[RequirePolicy("IntegrationTest")]
+public sealed record IntegrationTestRequest(int Value) : IRequest<int>;
+
 // Stub handlers — required by ZAM001 (every IRequest<T> needs a registered handler in the
 // compilation). Tests drive AuthorizationBehavior.Handle directly, bypassing the dispatcher,
 // so the handlers are never invoked.
@@ -106,6 +125,11 @@ public sealed class StubGetThingCancellableHandler : IRequestHandler<GetThingCan
 { public ValueTask<int> Handle(GetThingCancellable r, CancellationToken ct) => ValueTask.FromResult(0); }
 public sealed class StubGetThingUnauthorizedHandler : IRequestHandler<GetThingUnauthorized, int>
 { public ValueTask<int> Handle(GetThingUnauthorized r, CancellationToken ct) => ValueTask.FromResult(0); }
+public sealed class IntegrationTestHandler : IRequestHandler<IntegrationTestRequest, int>
+{
+    public ValueTask<int> Handle(IntegrationTestRequest r, CancellationToken ct)
+        => ValueTask.FromResult(r.Value * 2);
+}
 
 internal sealed record TestSecurityContext(string Id,
                                             IReadOnlySet<string> Roles,
@@ -122,6 +146,42 @@ internal static class TestSecurityContexts
         new TestSecurityContext("user-1",
             new HashSet<string>(roles, StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.Ordinal));
+}
+
+// Mutable counter resolved by CountingDownstreamBehavior to record whether
+// downstream pipeline behaviors ran on a given Send. AddSingleton in tests.
+internal sealed class InvocationCounter { public int Count; }
+
+// Local shim — the test-assembly's Mediator generator sees this in the
+// current compilation (cross-assembly AuthorizationBehavior is invisible to
+// it). The shim's static Handle just forwards to the real behavior. Same
+// Order constant (-1000), identical contract.
+[PipelineBehavior(Order = -1000)]
+public sealed class AuthorizationBehaviorShim : IPipelineBehavior
+{
+    public static ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request, CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+        => AuthorizationBehavior.Handle<TRequest, TResponse>(request, ct, next);
+}
+
+// Numerically AFTER the shim (-500 > -1000): runs only if the shim did NOT
+// short-circuit. The integration tests assert this counter to prove
+// pipeline ordering took effect.
+[PipelineBehavior(Order = -500)]
+public sealed class CountingDownstreamBehavior : IPipelineBehavior
+{
+    public static ValueTask<TResponse> Handle<TRequest, TResponse>(
+        TRequest request, CancellationToken ct,
+        Func<TRequest, CancellationToken, ValueTask<TResponse>> next)
+        where TRequest : IRequest<TResponse>
+    {
+        // Reads via AuthorizationBehaviorState (now public after Task 1).
+        AuthorizationBehaviorState.ServiceProvider!
+            .GetRequiredService<InvocationCounter>().Count++;
+        return next(request, ct);
+    }
 }
 
 // AuthorizationBehaviorState.ServiceProvider is mutated by AddMediator().WithAuthorization()


### PR DESCRIPTION
## Summary

Ships backlog items #4-#7 in one focused PR:

- **#4** — new \`Pipeline_ordering_authorization_runs_before_later_behaviors\` integration test that proves \`AuthorizationBehavior\`'s \`Order=-1000\` short-circuits before later behaviors fire. Swap-test verified pre-merge (changing the downstream stub's Order to \`-2000\` makes this test fail with \`counter.Count == 1\`, confirming the assertion catches real ordering regressions).
- **#5** — new \`End_to_end_through_IMediator_Send_{allow,deny}_path\` integration tests that exercise the real dispatcher → shim → real \`AuthorizationBehavior\` → \`AuthorizerFor\` → policy → handler chain.
- **#6** — AOT smoke drops the redundant \`policy.EvaluateAsync\` allocation gate (which certifies ZeroAlloc.Authorization, not Mediator.Authorization). The \`AuthorizationBehavior.Handle\` gate that does Mediator.Authorization's job stays.
- **#7** — \`<InternalsVisibleTo Include="ZeroAlloc.Mediator.AotSmoke" />\` removed from the Authorization csproj. The smoke now resolves the (newly-public) \`AuthorizationBehaviorAccessor\` from DI to trigger its static-init side effect.

The integration tests required a small additive PublicAPI change: \`AuthorizationBehaviorAccessor\` and \`AuthorizationBehaviorState\` promoted from \`internal\` to \`public\`. No signature changes, no removals.

## Why cross-assembly testing needed a shim

The Mediator source generator discovers \`[PipelineBehavior]\`-decorated behaviors only in the current compilation. \`AuthorizationBehavior\` lives in \`ZeroAlloc.Mediator.Authorization\` (a referenced assembly) and is invisible to the test assembly's generator. The new \`AuthorizationBehaviorShim\` (local to the test assembly) is a thin pass-through that the generator picks up; the shim forwards to \`AuthorizationBehavior.Handle\`. This is the only viable way to drive the real behavior through \`IMediator.Send\` from the test assembly.

## Design + plan

- Design: \`docs/plans/2026-05-22-mediator-authorization-integration-tests-design.md\`
- Plan: \`docs/plans/2026-05-22-mediator-authorization-integration-tests.md\`

## Test plan

- [ ] CI green: build + tests + aot-smoke
- [ ] AOT publish of the smoke still produces a working binary; allocation gates pass within budget
- [ ] Existing test suite still 100% green (31 tests = 28 previous + 3 new)
- [x] Swap-test for the ordering assertion verified manually pre-merge (documented inline at \`tests/.../IntegrationTests.cs\`)

## Followup (separate PR)

The test-assembly IVT to ZeroAlloc.Mediator.Authorization could be removed too, since the now-public \`AuthorizationBehaviorState\` covers the test fixture's needs. Left in for now to keep this PR focused on the smoke leak (#7); separate cleanup PR if/when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)