### PR TITLE
fix(generator)!: emit the generated mediator types as internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ obj/
 BenchmarkDotNet.Artifacts/
 
 !src/ZeroAlloc.Mediator.Cache/
+
+# Local AOT publish output (produced by scripts/ and manual dotnet publish runs).
+aot-out/

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -115,6 +115,27 @@ Mediator.Configure(c =>
 
 Once registered, `Mediator.Send(new GetProductQuery(...))` invokes the factory in place of `new GetProductHandler()`. The factory delegate is shared with `IMediator` for handlers that have one.
 
+## Visibility — the generated types are `internal` to your assembly
+
+`IMediator`, `MediatorService`, `MediatorConfig` and the static `Mediator` class are emitted by the generator into the assembly being compiled, not shipped in the `ZeroAlloc.Mediator` package. Their members are derived from the handlers discovered in *that* assembly — one strongly-typed `Send` overload per request handler, `Publish` per notification, `CreateStream` per stream request. That is what makes dispatch reflection-free.
+
+Because every assembly gets a differently-shaped copy, all of them are emitted **`internal`**. Two assemblies that both run the generator can then be referenced from a third project without their copies colliding.
+
+The practical consequence: `IMediator` cannot appear in a `public` signature, or the compiler reports **CS0051** ("inconsistent accessibility").
+
+```csharp
+// Won't compile — public type exposing an internal parameter.
+public sealed class OrderService(IMediator mediator);
+
+// Fine — the consuming type is internal too.
+internal sealed class OrderService(IMediator mediator);
+
+// Fine — lambdas have no declared accessibility.
+app.MapGet("/orders", async (IMediator mediator, CancellationToken ct) => …);
+```
+
+This is a constraint of the design rather than a limitation to work around: assembly A's `IMediator` and assembly B's `IMediator` are different types with different members, so a signature sharing one across a boundary was never meaningful. Types that need to cross assemblies should expose your own abstraction and take `IMediator` internally.
+
 ## Compatibility — migrating from 3.0.x
 
 - **`IMediator` is now Transient (was Singleton).** Behaviorally identical: dispatch is stateless either way. The only thing that changes is reference equality across resolutions — if you cached the singleton instance and compared with `ReferenceEquals`, that no longer holds. Cached references still work; they just no longer match a fresh `GetRequiredService<IMediator>()` call.

--- a/src/ZeroAlloc.Mediator.Generator/MediatorGenerator.cs
+++ b/src/ZeroAlloc.Mediator.Generator/MediatorGenerator.cs
@@ -434,7 +434,7 @@ namespace ZeroAlloc.Mediator.Generator
             sb.AppendLine();
             sb.AppendLine("namespace ZeroAlloc.Mediator");
             sb.AppendLine("{");
-            sb.AppendLine("    public static partial class Mediator");
+            sb.AppendLine("    internal static partial class Mediator");
             sb.AppendLine("    {");
 
             var validRequests = requestHandlers.Where(x => x != null).Select(x => x!).ToList();
@@ -718,7 +718,7 @@ namespace ZeroAlloc.Mediator.Generator
             List<StreamHandlerInfo> streamHandlers)
         {
             sb.AppendLine();
-            sb.AppendLine("    public sealed class MediatorConfig");
+            sb.AppendLine("    internal sealed class MediatorConfig");
             sb.AppendLine("    {");
             sb.AppendLine("        public void SetFactory<THandler>(Func<THandler> factory) where THandler : class");
             sb.AppendLine("        {");
@@ -766,7 +766,15 @@ namespace ZeroAlloc.Mediator.Generator
             List<NotificationHandlerInfo> notificationHandlers,
             List<StreamHandlerInfo> streamHandlers)
         {
-            sb.AppendLine("    public partial interface IMediator");
+            // Internal for the same reason as MediatorServiceCollectionExtensions: the members
+            // below are derived from the handlers discovered in *this* assembly, so every
+            // assembly running the generator gets a differently-shaped IMediator. Emitting it
+            // public made those copies visible to each other and any project referencing two
+            // such assemblies failed with CS0436 (issue #100).
+            //
+            // This type cannot live in the runtime package instead — a shared IMediator would
+            // have no members at all, since there are no handlers to derive them from.
+            sb.AppendLine("    internal partial interface IMediator");
             sb.AppendLine("    {");
 
             foreach (var handler in requestHandlers)
@@ -806,7 +814,7 @@ namespace ZeroAlloc.Mediator.Generator
             List<StreamHandlerInfo> streamHandlers,
             List<PipelineBehaviorInfo> pipelineBehaviors)
         {
-            sb.AppendLine("    public partial class MediatorService : IMediator");
+            sb.AppendLine("    internal partial class MediatorService : IMediator");
             sb.AppendLine("    {");
             sb.AppendLine("        private readonly global::System.IServiceProvider _services;");
             sb.AppendLine("        private static readonly global::System.Diagnostics.ActivitySource _activitySource = new(\"ZeroAlloc.Mediator\");");

--- a/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/DiInterfaceGeneratorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/DiInterfaceGeneratorTests.cs
@@ -27,7 +27,7 @@ public class DiInterfaceGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public partial interface IMediator", output);
+        Assert.Contains("internal partial interface IMediator", output);
         Assert.Contains("ValueTask<string> Send(global::TestApp.Ping request", output);
     }
 
@@ -53,7 +53,7 @@ public class DiInterfaceGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public partial interface IMediator", output);
+        Assert.Contains("internal partial interface IMediator", output);
         Assert.Contains("ValueTask Publish(global::TestApp.UserCreated notification", output);
     }
 
@@ -85,7 +85,7 @@ public class DiInterfaceGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public partial interface IMediator", output);
+        Assert.Contains("internal partial interface IMediator", output);
         Assert.Contains("IAsyncEnumerable<int> CreateStream(global::TestApp.CountTo request", output);
     }
 
@@ -111,7 +111,7 @@ public class DiInterfaceGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public partial class MediatorService : IMediator", output);
+        Assert.Contains("internal partial class MediatorService : IMediator", output);
         Assert.Contains("GetRequiredService<global::TestApp.PingHandler>(_services)", output);
     }
 
@@ -195,8 +195,8 @@ public class DiInterfaceGeneratorTests
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 
         // Interface has all three method types
-        var interfaceIdx = output.IndexOf("public partial interface IMediator", StringComparison.Ordinal);
-        var serviceIdx = output.IndexOf("public partial class MediatorService", StringComparison.Ordinal);
+        var interfaceIdx = output.IndexOf("internal partial interface IMediator", StringComparison.Ordinal);
+        var serviceIdx = output.IndexOf("internal partial class MediatorService", StringComparison.Ordinal);
         var interfaceSection = output.Substring(interfaceIdx, serviceIdx - interfaceIdx);
 
         Assert.Contains("Send(global::TestApp.Ping", interfaceSection);
@@ -237,7 +237,7 @@ public class DiInterfaceGeneratorTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
-        Assert.Contains("public partial class MediatorService", output);
+        Assert.Contains("internal partial class MediatorService", output);
         Assert.Contains("GetRequiredService<global::TestApp.HandlerA>(_services)", output);
         Assert.Contains("GetRequiredService<global::TestApp.HandlerB>(_services)", output);
         Assert.DoesNotContain("=> Mediator.Publish(notification, ct);", output);
@@ -266,7 +266,7 @@ public class DiInterfaceGeneratorTests
 
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 
-        Assert.Contains("public partial class MediatorService", output);
+        Assert.Contains("internal partial class MediatorService", output);
         Assert.Contains("private readonly global::System.IServiceProvider _services", output);
         Assert.Contains("public MediatorService(global::System.IServiceProvider services)", output);
         Assert.Contains(
@@ -337,7 +337,7 @@ public class DiInterfaceGeneratorTests
         Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 
         // The MediatorService.Send method must include the behavior chain wrapped around the handler resolution.
-        var serviceClassStart = output.IndexOf("public partial class MediatorService", StringComparison.Ordinal);
+        var serviceClassStart = output.IndexOf("internal partial class MediatorService", StringComparison.Ordinal);
         Assert.True(serviceClassStart >= 0, "MediatorService partial class missing");
         var serviceSection = output.Substring(serviceClassStart);
 

--- a/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/DiagnosticTests.cs
+++ b/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/DiagnosticTests.cs
@@ -460,7 +460,7 @@ public class DiagnosticTests
         var (output, diagnostics) = GeneratorTestHelper.RunGenerator(source);
 
         // Should still emit the Mediator class shell with Configure
-        Assert.Contains("public static partial class Mediator", output);
+        Assert.Contains("internal static partial class Mediator", output);
         Assert.Contains("Configure", output);
 
         // But no Send/Publish/CreateStream

--- a/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/GeneratedTypeVisibilityTests.cs
+++ b/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/GeneratedTypeVisibilityTests.cs
@@ -1,0 +1,92 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace ZeroAlloc.Mediator.Tests.GeneratorTests;
+
+/// <summary>
+/// Guards issue #100: every type the generator emits into the shared
+/// <c>ZeroAlloc.Mediator</c> namespace must be <c>internal</c>.
+/// <para>
+/// The generated members are derived from the handlers discovered in the assembly being
+/// compiled, so each assembly running the generator gets a differently-shaped copy. Emitting
+/// them <c>public</c> made those copies visible to one another, and any project referencing two
+/// such assemblies failed to compile with CS0436 — analyzer assets flow transitively through
+/// ProjectReference, so this hit ordinary multi-project solutions rather than an exotic setup.
+/// </para>
+/// <para>
+/// These types cannot move to the runtime package instead: a shared <c>IMediator</c> would have
+/// no members, because there would be no handlers to derive them from. Internal visibility is
+/// therefore the design, and this test states it explicitly — the other generator tests only
+/// match these declarations incidentally, as anchors for locating output.
+/// </para>
+/// </summary>
+public class GeneratedTypeVisibilityTests
+{
+    private const string HandlerSource = """
+        using ZeroAlloc.Mediator;
+        using System.Collections.Generic;
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        namespace TestApp;
+
+        public readonly record struct Ping(string Message) : IRequest<string>;
+
+        public class PingHandler : IRequestHandler<Ping, string>
+        {
+            public ValueTask<string> Handle(Ping request, CancellationToken ct)
+                => ValueTask.FromResult("Pong");
+        }
+
+        public readonly record struct Pinged(string Message) : INotification;
+
+        public class PingedHandler : INotificationHandler<Pinged>
+        {
+            public ValueTask Handle(Pinged notification, CancellationToken ct) => ValueTask.CompletedTask;
+        }
+        """;
+
+    [Theory]
+    [InlineData("interface IMediator")]
+    [InlineData("class MediatorService")]
+    [InlineData("class MediatorConfig")]
+    [InlineData("class Mediator")]
+    [InlineData("class MediatorServiceCollectionExtensions")]
+    public void GeneratedTypes_AreInternal(string declaration)
+    {
+        var (output, diagnostics) = GeneratorTestHelper.RunGenerator(HandlerSource);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+
+        // Asserting the absence of "public … <declaration>" rather than the presence of
+        // "internal … <declaration>" catches a new emission site that reintroduces public
+        // visibility, which a presence check on the existing site would miss.
+        var publicIndex = output.IndexOf("public ", StringComparison.Ordinal);
+        while (publicIndex >= 0)
+        {
+            var lineEnd = output.IndexOf('\n', publicIndex);
+            var line = lineEnd < 0
+                ? output.Substring(publicIndex)
+                : output.Substring(publicIndex, lineEnd - publicIndex);
+
+            Assert.False(
+                line.Contains(declaration, StringComparison.Ordinal),
+                $"Generated type must be internal (issue #100), found: {line.Trim()}");
+
+            publicIndex = output.IndexOf("public ", publicIndex + 1, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void GeneratedMediatorService_StillImplementsGeneratedInterface()
+    {
+        // Internal visibility must not change the shape: the concrete service still implements
+        // the generated interface, so consumers keep resolving IMediator from DI within their
+        // own assembly.
+        var (output, diagnostics) = GeneratorTestHelper.RunGenerator(HandlerSource);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Contains("internal partial class MediatorService : IMediator", output, StringComparison.Ordinal);
+        Assert.Contains("internal partial interface IMediator", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/PipelineBehaviorGeneratorTests.cs
+++ b/tests/ZeroAlloc.Mediator.Tests/GeneratorTests/PipelineBehaviorGeneratorTests.cs
@@ -104,8 +104,8 @@ public class PipelineBehaviorGeneratorTests
 
         // Constrain search to the static Mediator class — MediatorService also emits Send methods
         // (Task 7) that apply the same behavior chain, and we only want to verify scoping here.
-        var staticClassStart = output.IndexOf("public static partial class Mediator", StringComparison.Ordinal);
-        var staticClassEnd = output.IndexOf("public sealed class MediatorConfig", StringComparison.Ordinal);
+        var staticClassStart = output.IndexOf("internal static partial class Mediator", StringComparison.Ordinal);
+        var staticClassEnd = output.IndexOf("internal sealed class MediatorConfig", StringComparison.Ordinal);
         var staticSection = output.Substring(staticClassStart, staticClassEnd - staticClassStart);
 
         var pingSendIdx = staticSection.IndexOf("Send(global::TestApp.Ping", StringComparison.Ordinal);


### PR DESCRIPTION
Closes #100.

## The bug

The generator emits `IMediator`, `MediatorService`, `MediatorConfig` and the static `Mediator` class into the shared `ZeroAlloc.Mediator` namespace as **`public`**. Analyzer assets flow transitively through `ProjectReference`, so in any solution where project B references project A and both run the generator, B sees its own generated copy *and* A's:

```
error CS0436: The type 'IMediator' in '…\B\obj\…\ZeroAlloc.Mediator.g.cs' conflicts with
the imported type 'IMediator' in 'A, Version=…'
```

That's an ordinary multi-project layout. The reporter hit it across four downstream projects × two TFMs.

## The fix already existed next door

The generator **already** emits `MediatorServiceCollectionExtensions` as `internal`, with a comment spelling out this exact reasoning:

> *Internal so two assemblies that both run the ZeroAlloc.Mediator source generator can both be referenced from a third project without CS0121 ambiguity… Each consuming assembly gets its own internal copy.*

The core trio never followed it. All five emissions are now consistent.

## Resolving the design question the issue raised

The issue offered a second model — keep `IMediator` public by moving it to the runtime package, generating only the concrete service per assembly — and asked for an explicit decision, *"since they pull in opposite directions."*

**That model isn't viable.** The generated interface's members are derived from the handlers discovered in the assembly being compiled:

```csharp
foreach (var handler in requestHandlers)
    sb.AppendLine($"ValueTask<{handler.ResponseTypeName}> Send({handler.RequestTypeName} request, …);");
```

One `Send` overload per request handler, `Publish` per notification, `CreateStream` per stream request — that's what makes dispatch reflection-free. A shared `IMediator` in the runtime package would have **no members at all**. So internal is the only model consistent with the design, and this PR records that decision.

## Breaking change

`IMediator` can no longer appear in a `public` signature:

```csharp
public sealed class OrderService(IMediator mediator);    // CS0051 — inconsistent accessibility
internal sealed class OrderService(IMediator mediator);  // fine
app.MapGet("/orders", async (IMediator m, …) => …);      // fine — lambdas have no accessibility
```

This is a constraint of the design rather than a regression. Assembly A's `IMediator` and assembly B's are **distinct types with different members**, so a signature sharing one across a boundary never had a coherent meaning — it compiled only until a second generated copy appeared, which is precisely the CS0436 being fixed. Documented in `docs/dependency-injection.md` with the workaround (expose your own abstraction, take `IMediator` behind it).

## Tests

`GeneratedTypeVisibilityTests` asserts the **absence of a public declaration** rather than the presence of an internal one, so a *new* emission site that reintroduces public visibility is caught too — a presence check on today's sites would miss that.

- Verified non-vacuous: reverting one emission to `public` fails it (2 failures).
- Full suite green: **171 tests** across six projects.
- The existing generator tests matched these declarations only as *anchors* for locating output (`IndexOf`) or as existence checks — none asserted public visibility as a contract — so their expectations were updated in place.

## Note

`.gitignore` gains `aot-out/`, a local AOT publish directory that was untracked in the working tree and is trivially easy to commit by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
