### PR TITLE
docs: fix examples broken by the internal-visibility change

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ public class CreateOrderHandler : IRequestHandler<CreateOrder, OrderId>
 services.AddMediator();
 
 // 4. Send the request and use the result — fully strongly-typed, zero allocation
-public class OrderController(IMediator mediator)
+app.MapPost("/orders", async (CreateOrder cmd, IMediator mediator, CancellationToken ct) =>
 {
-    public async Task<IResult> PlaceOrder(CreateOrder cmd, CancellationToken ct)
-    {
-        var id = await mediator.Send(cmd, ct);   // returns OrderId, no boxing
-        return Results.Created($"/orders/{id}", id);
-    }
-}
+    var id = await mediator.Send(cmd, ct);   // returns OrderId, no boxing
+    return Results.Created($"/orders/{id}", id);
+});
 ```
+
+> `IMediator` is generated into your assembly and is `internal`, so it cannot appear in a
+> `public` signature. Endpoint lambdas and `internal` services are unaffected; see
+> [Visibility](docs/dependency-injection.md#visibility--the-generated-types-are-internal-to-your-assembly)
+> for the reasoning and the pattern for MVC controllers.
 
 ## Performance
 

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -136,6 +136,28 @@ app.MapGet("/orders", async (IMediator mediator, CancellationToken ct) => …);
 
 This is a constraint of the design rather than a limitation to work around: assembly A's `IMediator` and assembly B's `IMediator` are different types with different members, so a signature sharing one across a boundary was never meaningful. Types that need to cross assemblies should expose your own abstraction and take `IMediator` internally.
 
+### MVC controllers
+
+MVC controllers must be `public` to be discovered, so they cannot take `IMediator` in their constructor. Minimal APIs are unaffected — endpoint lambdas have no declared accessibility — so prefer them where you can. Where you need a controller, put an internal seam behind it:
+
+```csharp
+internal interface IOrderCommands
+{
+    ValueTask<OrderId> PlaceAsync(CreateOrder cmd, CancellationToken ct);
+}
+
+internal sealed class OrderCommands(IMediator mediator) : IOrderCommands
+{
+    public ValueTask<OrderId> PlaceAsync(CreateOrder cmd, CancellationToken ct)
+        => mediator.Send(cmd, ct);
+}
+
+// The controller is public; its dependency is your own abstraction, not IMediator.
+public sealed class OrdersController(IOrderCommands commands) : ControllerBase { … }
+```
+
+Registering `IOrderCommands` is an ordinary `services.AddScoped<IOrderCommands, OrderCommands>()` — an internal service type is fine for DI, since the container resolves by type rather than by signature.
+
 ## Compatibility — migrating from 3.0.x
 
 - **`IMediator` is now Transient (was Singleton).** Behaviorally identical: dispatch is stateless either way. The only thing that changes is reference equality across resolutions — if you cached the singleton instance and compared with `ReferenceEquals`, that no longer holds. Cached references still work; they just no longer match a fresh `GetRequiredService<IMediator>()` call.


### PR DESCRIPTION
Follow-up to #101.

## The README's headline example no longer compiles

#101 made the generated `IMediator` internal. The README then showed:

```csharp
public class OrderController(IMediator mediator)
```

which now fails with **CS0051** — confirmed by compiling the shape, not by reasoning about it:

```
error CS0051: Inconsistent accessibility: parameter type 'IMediator' is less
accessible than method 'OrderController.OrderController(IMediator)'
```

Replaced with a minimal-API endpoint, which is unaffected because lambdas have no declared accessibility, plus a pointer to the visibility section.

## MVC controllers — the edge I under-weighted in #101

That PR covered minimal APIs and internal services, and both are genuinely fine. **MVC controllers are not.** A controller must be `public` to be discovered, so it cannot take `IMediator` in its constructor at all — there's no "make it internal" escape, because that would stop it being a controller.

The DI guide now documents the pattern: an internal seam between the controller and the mediator.

```csharp
internal interface IOrderCommands { … }
internal sealed class OrderCommands(IMediator mediator) : IOrderCommands { … }

public sealed class OrdersController(IOrderCommands commands) : ControllerBase { … }
```

Registering an internal service type is fine — the container resolves by type, not by signature.

## Worth deciding

This doesn't change my view that internal is the right model: the alternative is CS0436 in any multi-project solution, and a package-level `IMediator` can't work because the members are per-assembly. But MVC is a common enough shape that it deserves to be a documented pattern rather than something adopters rediscover from a compiler error — which is what this PR fixes.

If the friction turns out to be worse than expected in practice, the remaining option is emitting the types into a per-assembly namespace so they can stay public. That trades a compile error for a namespace that differs per assembly, so I'd want evidence it's needed before proposing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
