### PR TITLE
chore(release): make release-please single-package and pack Authorization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           dotnet pack src/ZeroAlloc.Mediator.Validation/ZeroAlloc.Mediator.Validation.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Mediator.Resilience/ZeroAlloc.Mediator.Resilience.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Mediator.Telemetry/ZeroAlloc.Mediator.Telemetry.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Mediator.Authorization/ZeroAlloc.Mediator.Authorization.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: Verify generator pack layout
         run: bash scripts/verify-generator-pack-layout.sh ./artifacts

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-  ".": "4.1.4",
-  "src/ZeroAlloc.Mediator.Authorization": "2.0.0"
+  ".": "4.1.4"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,12 +6,6 @@
       "package-name": "ZeroAlloc.Mediator",
       "component": "mediator",
       "include-component-in-tag": false
-    },
-    "src/ZeroAlloc.Mediator.Authorization": {
-      "release-type": "simple",
-      "package-name": "ZeroAlloc.Mediator.Authorization",
-      "component": "authorization",
-      "include-component-in-tag": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Unblocks releases. Nothing has shipped from this repo since **2026-05-21**.

## What was wrong

Every release-please run since May has aborted:

```
❯ Found pull request #90: 'chore: release main'
⚠ There are untagged, merged release PRs outstanding - aborting
```

So #98, #99 and #101 all merged with no release — and #101 is a breaking change that would otherwise propose **5.0.0**.

The cause is a config that doesn't match how this repo ships:

| | declares | reality |
|---|---|---|
| `release-please-config.json` | `Authorization` is a separate component, `include-component-in-tag: true` | — |
| `.release-please-manifest.json` | `Authorization` at **2.0.0** | — |
| `release.yml` | — | one version from the **single root tag**, packs everything with it |
| nuget.org | — | `ZeroAlloc.Mediator.Authorization` at **4.1.1 … 4.1.4** — tracks root, never 2.0.0 |

Release-please expected an `authorization-v2.0.0` tag for the component release #90 made. Nothing in the pipeline creates such a tag, so it waited forever.

## What this changes

- Removes the phantom `Authorization` component from the config and manifest, so release-please matches the pipeline and nuget
- **Adds `ZeroAlloc.Mediator.Authorization` to `release.yml`'s pack list**, which had omitted it

I backfilled the missing tag separately — `authorization-v2.0.0` on `2413622a` (#90's merge commit) — to clear the currently stuck PR. That publishes nothing: no workflow triggers on tag push, only on `release: published`. This PR stops the deadlock recurring on the next authorization-scoped release.

## The pack-list omission is worth a look

Auditing every packable project against `release.yml` showed Authorization was the only one missing:

```
ZeroAlloc.Mediator.Authorization   PACKABLE   ** MISSING **   <- before this PR
ZeroAlloc.Mediator.Cache           PACKABLE   in-pack-list
ZeroAlloc.Mediator.Generator       PACKABLE   in-pack-list
…
```

Left alone, the next release would publish six packages and strand Authorization at 4.1.4 while everything else moved to 5.0.0 — which is precisely the stale-hardcoded-list failure `publish-from-manifest.yml` was written to rescue.

## Separately noticed, not addressed here

`ZeroAlloc.Mediator.Authorization.Generator` is **published on nuget at 4.1.3**, but its source project no longer exists — `src/ZeroAlloc.Mediator.Authorization.Generator/` contains only stale `bin`/`obj`, and nothing in the repo references it. It looks folded into `ZeroAlloc.Mediator.Authorization`. Anyone still on that package gets no updates; worth deprecating on nuget and deleting the leftover directory, but that's a separate decision.

## After merge

Release-please should propose **5.0.0** — `fix(generator)!` from #101 carries both the `!` marker and a `BREAKING CHANGE:` footer, and both survived the squash onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
