### PR TITLE
fix(ci): add --skip-duplicate to the NuGet push so a conflict cannot abort the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,9 @@ jobs:
         run: bash scripts/verify-generator-pack-layout.sh ./artifacts
 
       - name: Push to NuGet
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        # --skip-duplicate is required, not cosmetic. dotnet nuget push fails fast on a glob:
+        # one 409 aborts the whole command and every package after it in the list is never
+        # pushed. Without it, a single already-claimed version leaves the release partially
+        # published and the job unrepeatable, because re-running hits the same conflict again.
+        # This matches how the other repos in the org push.
+        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
The v5.0.0 release failed to publish. This fixes the mechanism; recovering 5.0.0 needs one more step, described below.

## What happened

```
Pushing ZeroAlloc.Mediator.5.0.0.nupkg to 'https://www.nuget.org/api/v2/package'...
  Conflict https://www.nuget.org/api/v2/package/ 222ms
  To skip already published packages, use the option --skip-duplicate
error: 409 (A package with ID 'ZeroAlloc.Mediator' and version '5.0.0' already exists…)
```

`Pack` and `Verify generator pack layout` both succeeded. Only the push failed.

## Why it's worse than one skipped package

`dotnet nuget push` **fails fast on a glob**. It aborted on the first file, so the remaining six — Generator, Cache, Validation, Resilience, Telemetry and **Authorization** — were never attempted. The release is partially published, and re-running the job just hits the same conflict again.

`--skip-duplicate` makes the push idempotent: a claimed version is skipped and everything else still publishes. Every other repo in the org already passes it, and so does **this repo's own `publish-from-manifest.yml`**. `release.yml` was the only push missing it.

This doesn't mask real failures. A conflict on a fresh release means the version was claimed upstream — not something a release job can fix. What it *should* do is publish the rest rather than stop at the first.

## About the conflict itself

`ZeroAlloc.Mediator 5.0.0` is claimed on nuget.org but invisible: the blob 404s and it's absent from the registration index. That's the reserved-during-validation state — the same lag that delayed ValueObjects and Validation by ~1.5h earlier today. Only one Release run exists for v5.0.0 (this failed one), so I can't attribute the original push from CI history alone.

Either way it's unrecoverable by re-push: NuGet never permits reusing a version, even one that is unlisted or still validating.

## Recovering the 5.0.0 release

Merging this is not sufficient on its own — re-running the Release workflow requires a `release: published` event.

The clean recovery is to dispatch **`publish-from-manifest.yml`**, which exists for exactly this case. It walks every `src/*/*.csproj`, packs at the manifest version (now `5.0.0`), and pushes with `--skip-duplicate` — so `ZeroAlloc.Mediator` is skipped and the other six publish.

I have not dispatched it: that publishes to nuget.org and is yours to authorise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
