### PR TITLE
chore(renovate): adopt the shared preset, drop the weekly window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>ZeroAlloc-Net/.github"
   ],
-  "schedule": [
-    "before 6am on monday"
-  ],
-  "timezone": "Europe/Amsterdam",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
> **Blocked on [ZeroAlloc-Net/.github#19](https://github.com/ZeroAlloc-Net/.github/pull/19).** Until that preset is on `main`, `github>ZeroAlloc-Net/.github` will not resolve and Renovate will error on this repo. Merge #19 first.

Replaces this repo's weekly Renovate window with a three-day stabilisation period, and exempts security fixes from it.

## What changes

```diff
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>ZeroAlloc-Net/.github"
   ],
-  "schedule": ["before 6am on monday"],
-  "timezone": "Europe/Amsterdam",
```

The schedule has to be deleted **here** rather than in the preset — repo config wins over a preset, so leaving it would keep the Monday window in force and negate the change entirely. `timezone` goes with it, since it only ever affected `schedule`.

## Why

The window was doing two jobs: batching updates, and letting a release sit long enough to be found broken. The preset keeps the second via `minimumReleaseAge: "3 days"` and drops the batching — an update published on Tuesday now arrives Friday instead of waiting for the following Monday.

More importantly, **security updates inherited that schedule**. `ZeroAlloc.Serialisation` had MessagePack 3.1.8 parked under *Awaiting Schedule* on its dependency dashboard while 3.1.4 carried fourteen advisories, three high severity — with audit-as-error making `main` unbuildable for two months, unnoticed because CI only runs on `push` and `pull_request`.

Under the preset, security fixes bypass both the wait and any schedule, and are raised as `fix(deps)` so release-please actually ships them. As `chore` they would merge to main and leave the published package vulnerable.

## Note

Routine update cadence is otherwise unchanged; any `packageRules`, grouping and automerge settings in this repo are untouched.
